### PR TITLE
Pre-pull images in parallel on controllers using a workpool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/avast/retry-go v2.6.0+incompatible
+	github.com/gammazero/workerpool v0.0.0-20200311205957-7b00833861c6
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gammazero/deque v0.0.0-20200227231300-1e9af0e52b46 h1:iX4+rD9Fjdx8SkmSO/O5WAIX/j79ll3kuqv5VdYt9J8=
+github.com/gammazero/deque v0.0.0-20200227231300-1e9af0e52b46/go.mod h1:D90+MBHVc9Sk1lJAbEVgws0eYEurY4mv2TDso3Nxh3w=
+github.com/gammazero/workerpool v0.0.0-20200311205957-7b00833861c6 h1:1Cy/haf7XO4OyrkGid0Wq5CMluIErbvDptVAt8UTy38=
+github.com/gammazero/workerpool v0.0.0-20200311205957-7b00833861c6/go.mod h1:/XWO2YAUUpPi3smDlFBl0vpX0JHwUomDM/oRMwRmnSs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=

--- a/pkg/phase/pull_images.go
+++ b/pkg/phase/pull_images.go
@@ -1,50 +1,69 @@
 package phase
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/Mirantis/mcc/pkg/config"
 	"github.com/Mirantis/mcc/pkg/host"
-	retry "github.com/avast/retry-go"
+	"github.com/gammazero/workerpool"
 	log "github.com/sirupsen/logrus"
 )
 
 type PullImages struct{}
-
-// FIXME Version needs to come from config
-var Images = []string{"docker/ucp:3.3.0-rc1"}
 
 func (p *PullImages) Title() string {
 	return "Pull images"
 }
 
 func (p *PullImages) Run(config *config.ClusterConfig) error {
+
+	images, err := p.listImages(config)
+	if err != nil {
+		return err
+	}
+	log.Debugf("loaded images list: %v", images)
 	var wg sync.WaitGroup
 	for _, host := range config.Controllers() {
 		wg.Add(1)
-		go p.pullImages(host, &wg)
+		go p.pullImages(host, images, &wg)
 	}
 	wg.Wait()
 
 	return nil
 }
 
-func (p *PullImages) pullImages(host *host.Host, wg *sync.WaitGroup) error {
+func (p *PullImages) listImages(config *config.ClusterConfig) ([]string, error) {
+	controller := config.Controllers()[0]
+	err := controller.PullImage(InstallerImage)
+	if err != nil {
+		return []string{}, err
+	}
+	output, err := controller.ExecWithOutput(fmt.Sprintf("sudo docker run --rm %s images --list", InstallerImage))
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to get image list")
+	}
+
+	return strings.Split(output, "\n"), nil
+}
+
+// Pulls images on a host in parallel using a workerpool with 5 workers. Essentially we pull 5 images in parallel.
+func (p *PullImages) pullImages(host *host.Host, images []string, wg *sync.WaitGroup) error {
 	defer wg.Done()
-	for _, image := range Images {
-		err := retry.Do(
-			func() error {
-				log.Debugf("Starting to pull image: %s", image)
-				err := host.PullImage(image)
-				if err == nil {
-					log.Infof("Pulled %s sucesfully", image)
-				}
-				return err
-			},
-		)
-		if err != nil {
-			return err
-		}
+
+	wp := workerpool.New(5)
+	defer wp.StopWait()
+
+	for _, image := range images {
+		i := image // So we can safely pass i forward to pool without it getting mutated
+		wp.Submit(func() {
+			log.Debugf("%s: pulling image %s", host.Address, i)
+			e := host.PullImage(i)
+			if e != nil {
+				log.Warnf("%s: failed to pull image %s", host.Address, i)
+			}
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

This shaves ~150secs off from the install process