### PR TITLE
Fix footloose example hostPort conflict

### DIFF
--- a/examples/footloose/cluster.yaml
+++ b/examples/footloose/cluster.yaml
@@ -4,6 +4,6 @@ hosts:
     user: "root"
     role: "controller"
   - address: "127.0.0.1"
-    sshPort: 9023
+    sshPort: 9122
     user: "root"
     role: "worker"

--- a/examples/footloose/footloose.yaml
+++ b/examples/footloose/footloose.yaml
@@ -22,7 +22,7 @@ machines:
     - containerPort: 22
       hostPort: 9022
     - containerPort: 443
-      hostPort: 443
+      hostPort: 9443
 - count: 1
   backend: docker
   spec:
@@ -41,4 +41,4 @@ machines:
       destination: /var/lib/kubelet
     portMappings:
     - containerPort: 22
-      hostPort: 9022
+      hostPort: 9122


### PR DESCRIPTION
The ssh `hostPort` for both machines was 9022. Now 9022 + 9122. (443 mapped to 9443 to avoid conflicting with any local https service)

```yaml
cluster:
  name: ucp
  privateKey: ~/.ssh/id_rsa
machines:
- count: 1
  backend: docker
  spec:
    image: quay.io/footloose/ubuntu18.04
    name: controller%d
    portMappings:
    - containerPort: 22
      hostPort: 9022 # <--
    - containerPort: 443
      hostPort: 443
- count: 1
  backend: docker
  spec:
    image: quay.io/footloose/ubuntu18.04
    name: worker%d
    portMappings:
    - containerPort: 22
      hostPort: 9022 # <--
```

```
INFO[0000] Pulling image: quay.io/footloose/ubuntu18.04 ...
INFO[0029] Image: quay.io/footloose/ubuntu18.04 present locally
INFO[0029] Creating machine: ucp-controller0 ...
INFO[0030] Creating machine: ucp-worker0 ...
ERRO[0030] Error response from daemon: driver failed programming external connectivity on endpoint ucp-worker0 (614f969883180a91651d287de87f92b75b62188c2a213e5cd22b97aa1074d887): Bind for 0.0.0.0:9022 failed: port is already allocated
ERRO[0030] Error: failed to start containers: ucp-worker0
FATA[0030] exit status 1
```