### PR TITLE
Normalize logrus usages

### DIFF
--- a/pkg/config/host.go
+++ b/pkg/config/host.go
@@ -11,7 +11,6 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -118,7 +117,7 @@ func (h *Host) Exec(cmd string) error {
 		return err
 	}
 
-	logrus.Debugf("executing command: %s", cmd)
+	log.Debugf("executing command: %s", cmd)
 	if err := session.Start(cmd); err != nil {
 		return err
 	}
@@ -127,10 +126,10 @@ func (h *Host) Exec(cmd string) error {
 	outputScanner := bufio.NewScanner(multiReader)
 
 	for outputScanner.Scan() {
-		logrus.Debugf("%s:  %s", h.Address, outputScanner.Text())
+		log.Debugf("%s:  %s", h.Address, outputScanner.Text())
 	}
 	if err := outputScanner.Err(); err != nil {
-		logrus.Errorf("%s:  %s", h.Address, err.Error())
+		log.Errorf("%s:  %s", h.Address, err.Error())
 	}
 
 	return nil

--- a/pkg/phase/connect.go
+++ b/pkg/phase/connect.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Mirantis/mcc/pkg/config"
 	retry "github.com/avast/retry-go"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // Connect connects to each of the hosts
@@ -31,19 +31,19 @@ func (p *Connect) connectHost(host *config.Host, wg *sync.WaitGroup) error {
 	defer wg.Done()
 	err := retry.Do(
 		func() error {
-			logrus.Infof("%s: opening SSH connection", host.Address)
+			log.Infof("%s: opening SSH connection", host.Address)
 			err := host.Connect()
 			if err != nil {
-				logrus.Errorf("%s: failed to connect -> %s", host.Address, err.Error())
+				log.Errorf("%s: failed to connect -> %s", host.Address, err.Error())
 			}
 			return err
 		},
 	)
 	if err != nil {
-		logrus.Errorf("%s: failed to open connection", host.Address)
+		log.Errorf("%s: failed to open connection", host.Address)
 		return err
 	}
 
-	logrus.Printf("%s: SSH connection opened", host.Address)
+	log.Printf("%s: SSH connection opened", host.Address)
 	return nil
 }

--- a/pkg/phase/disconnect.go
+++ b/pkg/phase/disconnect.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/Mirantis/mcc/pkg/config"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type Disconnect struct{}
@@ -27,6 +27,6 @@ func (p *Disconnect) Run(config *config.ClusterConfig) error {
 func (p *Disconnect) disconnectHost(host *config.Host, wg *sync.WaitGroup) error {
 	defer wg.Done()
 	host.Connect()
-	logrus.Printf("%s: SSH connection closed", host.Address)
+	log.Printf("%s: SSH connection closed", host.Address)
 	return nil
 }

--- a/pkg/phase/install_engine.go
+++ b/pkg/phase/install_engine.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Mirantis/mcc/pkg/config"
 	retry "github.com/avast/retry-go"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type InstallEngine struct{}
@@ -29,19 +29,19 @@ func (p *InstallEngine) installEngine(host *config.Host, engineConfig *config.En
 	defer wg.Done()
 	err := retry.Do(
 		func() error {
-			logrus.Infof("%s: installing base packages", host.Address)
+			log.Infof("%s: installing base packages", host.Address)
 			err := host.Configurer.InstallBasePackages()
-			logrus.Infof("%s: installing engine", host.Address)
+			log.Infof("%s: installing engine", host.Address)
 			err = host.Configurer.InstallEngine(engineConfig)
 
 			return err
 		},
 	)
 	if err != nil {
-		logrus.Errorf("%s: failed to install engine -> %s", host.Address, err.Error())
+		log.Errorf("%s: failed to install engine -> %s", host.Address, err.Error())
 		return err
 	}
 
-	logrus.Printf("%s: Engine installed", host.Address)
+	log.Printf("%s: Engine installed", host.Address)
 	return nil
 }

--- a/pkg/phase/ucp_phases.go
+++ b/pkg/phase/ucp_phases.go
@@ -2,7 +2,7 @@ package phase
 
 import (
 	"github.com/Mirantis/mcc/pkg/config"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type PhaseManager struct {
@@ -26,7 +26,7 @@ func (m *PhaseManager) AddPhase(phase Phase) {
 // Run executes all the added Phases in order
 func (m *PhaseManager) Run() error {
 	for _, phase := range m.phases {
-		logrus.Infof("==> Running phase: %s", phase.Title())
+		log.Infof("==> Running phase: %s", phase.Title())
 		err := phase.Run(m.config)
 		if err != nil {
 			return err


### PR DESCRIPTION
Makes all logrus usages use the convention of:

```go
import (
  log "github.com/sirupsen/logrus"
)

func Foo() {
  log.Infof("foofoo: %s", foo)
}
```

