### PR TITLE
Fix upgrade check

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -40,11 +40,7 @@ func Install(ctx *cli.Context) error {
 	phaseManager.AddPhase(&phase.PullImages{})
 	phaseManager.AddPhase(&phase.InitSwarm{})
 	phaseManager.AddPhase(&phase.InstallUCP{})
-	// Re-gather all the facts after install
-	phaseManager.AddPhase(&phase.GatherUcpFacts{})
 	phaseManager.AddPhase(&phase.UpgradeUcp{})
-	// Re-gather all the facts after upgrade
-	phaseManager.AddPhase(&phase.GatherUcpFacts{})
 	phaseManager.AddPhase(&phase.JoinControllers{})
 	phaseManager.AddPhase(&phase.JoinWorkers{})
 	phaseManager.AddPhase(&phase.Disconnect{})

--- a/pkg/phase/install_ucp.go
+++ b/pkg/phase/install_ucp.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Mirantis/mcc/pkg/config"
+	"github.com/Mirantis/mcc/pkg/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -32,5 +33,12 @@ func (p *InstallUCP) Run(config *config.ClusterConfig) error {
 	if err != nil {
 		return NewError("Failed to run UCP installer")
 	}
+
+	ucpMeta, err := util.CollectUcpFacts(swarmLeader)
+	if err != nil {
+		return fmt.Errorf("%s: failed to collect existing UCP details: %s", swarmLeader.Address, err.Error())
+	}
+	config.Ucp.Metadata = ucpMeta
+
 	return nil
 }

--- a/pkg/phase/upgrade.go
+++ b/pkg/phase/upgrade.go
@@ -42,5 +42,11 @@ func (p *UpgradeUcp) Run(config *config.ClusterConfig) error {
 		return NewError("Failed to run UCP upgrade")
 	}
 
+	ucpMeta, err := util.CollectUcpFacts(swarmLeader)
+	if err != nil {
+		return fmt.Errorf("%s: failed to collect existing UCP details: %s", swarmLeader.Address, err.Error())
+	}
+	config.Ucp.Metadata = ucpMeta
+
 	return nil
 }

--- a/pkg/util/ucp.go
+++ b/pkg/util/ucp.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"strings"
+
+	"github.com/Mirantis/mcc/pkg/config"
+)
+
+// CollectUcpFacts gathers the current status of installed UCP setup
+// Currently we only need to know the existing version and whether UCP is installed or not.
+// In future we probably need more.
+func CollectUcpFacts(swarmLeader *config.Host) (*config.UcpMetadata, error) {
+	output, err := swarmLeader.ExecWithOutput(`sudo docker inspect --format '{{ index .Config.Labels "com.docker.ucp.version"}}' ucp-proxy`)
+	if err != nil {
+		// We need to check the output to check if the container does not exist
+		if strings.Contains(output, "No such object") {
+			return &config.UcpMetadata{Installed: false}, nil
+		}
+		return nil, err
+	}
+	ucpMeta := &config.UcpMetadata{
+		Installed:        true,
+		InstalledVersion: output,
+	}
+	return ucpMeta, nil
+}


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

Install for some reason did not fill-in the UCP "facts" after succesfully install hence the upgrade check was falsely running the upgrade always. 🤦 

We probably need to gather more details of the setup as we go on so I thought it would make sense to do the full facts gathering after both install and upgrade