### PR TITLE
Add windows worker support to tf-aws example

### DIFF
--- a/examples/tf-aws/modules/common/main.tf
+++ b/examples/tf-aws/modules/common/main.tf
@@ -35,6 +35,22 @@ data "aws_ami" "ubuntu" {
   owners = ["099720109477"] # Canonical
 }
 
+data "aws_ami" "windows_2019" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["testkit/win_core2019/*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["546848686991"] # Mirantis?
+}
+
 resource "aws_security_group" "common" {
   name        = "${var.cluster_name}-common"
   description = "ucp cluster common rules"

--- a/examples/tf-aws/modules/common/outputs.tf
+++ b/examples/tf-aws/modules/common/outputs.tf
@@ -1,9 +1,13 @@
 output "security_group_id" {
-  value = "${aws_security_group.common.id}"
+  value = aws_security_group.common.id
 }
 
 output "image_id" {
-  value = "${data.aws_ami.ubuntu.id}"
+  value = data.aws_ami.ubuntu.id
+}
+
+output "windows_2019_image_id" {
+  value = data.aws_ami.windows_2019.id
 }
 
 output "availability_zones" {

--- a/examples/tf-aws/modules/windows_worker/main.tf
+++ b/examples/tf-aws/modules/windows_worker/main.tf
@@ -1,0 +1,47 @@
+resource "aws_security_group" "worker" {
+  name        = "${var.cluster_name}-win-workers"
+  description = "ucp cluster windows workers"
+  vpc_id      = var.vpc_id
+}
+
+locals {
+  subnet_count = length(var.subnet_ids)
+}
+
+
+resource "aws_instance" "ucp_worker" {
+  count = var.worker_count
+
+  tags = map(
+    "Name", "${var.cluster_name}-win-worker-${count.index + 1}",
+    "Role", "worker",
+    "${var.kube_cluster_tag}", "shared"
+  )
+
+  instance_type          = var.worker_type
+  iam_instance_profile   = var.instance_profile_name
+  ami                    = var.image_id
+  key_name               = var.ssh_key
+  vpc_security_group_ids = [var.security_group_id, aws_security_group.worker.id]
+  subnet_id              = var.subnet_ids[count.index % local.subnet_count]
+  ebs_optimized          = true
+#   user_data              = <<EOF
+# <powershell>
+# # Rename computer
+# Rename-Computer -NewName (Resolve-DnsName -Name (Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias "Ethernet 3").IPAddress -DnsOnly).NameHost
+
+# # Restart computer
+# Restart-Computer
+# </powershell>
+# EOF
+
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = var.worker_volume_size
+  }
+}

--- a/examples/tf-aws/modules/windows_worker/outputs.tf
+++ b/examples/tf-aws/modules/windows_worker/outputs.tf
@@ -1,0 +1,6 @@
+output "private_ips" {
+    value = aws_instance.ucp_worker.*.private_ip
+}
+output "machines" {
+  value = aws_instance.ucp_worker.*
+}

--- a/examples/tf-aws/modules/windows_worker/variables.tf
+++ b/examples/tf-aws/modules/windows_worker/variables.tf
@@ -1,0 +1,31 @@
+variable "cluster_name" {}
+
+variable "vpc_id" {}
+
+variable "instance_profile_name" {}
+
+variable "security_group_id" {}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "image_id" {}
+
+variable "kube_cluster_tag" {}
+
+variable "ssh_key" {
+  description = "SSH key name"
+}
+
+variable "worker_count" {
+  default = 0
+}
+
+variable "worker_type" {
+  default = "m5.large"
+}
+
+variable "worker_volume_size" {
+  default = 100
+}

--- a/examples/tf-aws/terraform.tfvars.example
+++ b/examples/tf-aws/terraform.tfvars.example
@@ -1,4 +1,5 @@
 cluster_name = "my-ucp-cluster"
 master_count = 1
 worker_count = 3
-admin_password = "v3rys3cretzzz!"
+windows_worker_count = 0
+admin_password = "orcaorcaorca"

--- a/examples/tf-aws/variables.tf
+++ b/examples/tf-aws/variables.tf
@@ -23,6 +23,10 @@ variable "worker_count" {
   default = 3
 }
 
+variable "windows_worker_count" {
+  default = 0
+}
+
 variable "master_type" {
   default = "m5.large"
 }


### PR DESCRIPTION
Note: we cannot enabled aws cloud provider if/when cluster has windows workers (see: https://mirantis.jira.com/browse/ENGORC-7329)