### PR TITLE
Fix exec error from auto-merge

### DIFF
--- a/pkg/config/host.go
+++ b/pkg/config/host.go
@@ -226,7 +226,7 @@ func (h *Host) AuthenticateDocker(server string) error {
 		log.Infof("%s: authenticating docker", h.Address)
 		old := log.GetLevel()
 		log.SetLevel(log.ErrorLevel)
-		err := h.ExecCmd(h.Configurer.DockerCommandf("login -u %s --password-stdin %s", user, server), pass, false, false)
+		err := h.ExecCmd(h.Configurer.DockerCommandf("login -u %s --password-stdin %s", user, server), pass, false, true)
 		log.SetLevel(old)
 
 		if err != nil {


### PR DESCRIPTION
```
# github.com/Mirantis/mcc/pkg/config

pkg/config/host.go:229:19: not enough arguments in call to h.ExecCmd

	have (string, string, bool)

	want (string, string, bool, bool)

# github.com/Mirantis/mcc/pkg/config [github.com/Mirantis/mcc/pkg/config.test]

pkg/config/host.go:229:19: not enough arguments in call to h.ExecCmd

	have (string, string, bool)

	want (string, string, bool, bool)

FAIL	github.com/Mirantis/mcc/pkg/analytics [build failed]

FAIL	github.com/Mirantis/mcc/pkg/config [build failed]
```
