### PR TITLE
Configure engine on installation

### DIFF
--- a/examples/footloose/cluster.yaml
+++ b/examples/footloose/cluster.yaml
@@ -10,8 +10,14 @@ spec:
       sshPort: 9023
       user: "root"
       role: "worker"
+      engineConfig: linuxworker
   ucp:
     installFlags:
       - --admin-username=admin
       - --admin-password=orcaorcaorca
       - --default-node-orchestrator=kubernetes
+  engine:
+    config:
+      - name: linuxworker
+        config:
+          debug: true

--- a/pkg/apis/v1beta1/engine_config.go
+++ b/pkg/apis/v1beta1/engine_config.go
@@ -1,15 +1,18 @@
 package v1beta1
 
 import (
+	"encoding/json"
+
 	"github.com/Mirantis/mcc/pkg/constant"
 )
 
 // EngineConfig holds the engine installation specific options
 type EngineConfig struct {
-	Version    string `yaml:"version"`
-	RepoURL    string `yaml:"repoUrl"`
-	InstallURL string `yaml:"installURL"`
-	Channel    string `yaml:"channel"`
+	Version        string             `yaml:"version"`
+	RepoURL        string             `yaml:"repoUrl"`
+	InstallURL     string             `yaml:"installURL"`
+	Channel        string             `yaml:"channel"`
+	Configurations []EngineHostConfig `yaml:"config"`
 }
 
 // UnmarshalYAML puts in sane defaults when unmarshaling from yaml
@@ -33,4 +36,27 @@ func NewEngineConfig() EngineConfig {
 		RepoURL:    constant.EngineRepoURL,
 		InstallURL: constant.EngineInstallURL,
 	}
+}
+
+// GetDaemonConfig gets the named daemon config
+func (c *EngineConfig) GetDaemonConfig(name string) *EngineHostConfig {
+	for _, ehc := range c.Configurations {
+		if name == ehc.Name {
+			return &ehc
+		}
+	}
+
+	return nil
+}
+
+// EngineHostConfig defines the named host level engine config options, essentially the daemon.json equivalent which will
+// be injected into hosts when installing engine.
+type EngineHostConfig struct {
+	Name   string
+	Config map[string]interface{}
+}
+
+// ToDaemonJSON converts the engine config into daemon.json data
+func (ec *EngineHostConfig) ToDaemonJSON() ([]byte, error) {
+	return json.Marshal(ec.Config)
 }


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

Alternative to #75

Config example:
```
apiVersion: "launchpad.mirantis.com/v1beta1"
kind: UCP
spec:
  hosts:
    - address: "127.0.0.1"
      sshPort: 9022
      user: "root"
      role: "manager"
    - address: "127.0.0.1"
      sshPort: 9023
      user: "root"
      role: "worker"
      engineConfig: linuxworker
  ucp:
    installFlags:
      - --admin-username=admin
      - --admin-password=orcaorcaorca
      - --default-node-orchestrator=kubernetes
  engine:
    config:
      - name: linuxworker
        config:
          debug: true
```

So essentially uses a name based referencing model between a host and named engine configs.

Pros:
- no repetition
- each host, or group of hosts,  can use different configs

Cons:
- referencing model is probably a bit error prone
- difficult to inject default stuff, e.g. selinux flags on EL based distros 
- `engine.config[].config`  has lot of padding and is weird :)

TODO:

- [ ] need to write the config on Windows
- [ ] Use the `GenericHash` stuff from #75