### PR TITLE
Add host address to all exec logs

### DIFF
--- a/pkg/apis/v1beta1/hosts.go
+++ b/pkg/apis/v1beta1/hosts.go
@@ -143,7 +143,7 @@ func (h *Host) ExecCmd(cmd string, stdin string, streamStdout bool, sensitiveCom
 	}
 
 	if !sensitiveCommand {
-		log.Debugf("executing command: %s", cmd)
+		log.Debugf("%s: executing command: %s", h.Address, cmd)
 	}
 
 	if err := session.Start(cmd); err != nil {
@@ -151,7 +151,7 @@ func (h *Host) ExecCmd(cmd string, stdin string, streamStdout bool, sensitiveCom
 	}
 
 	if stdin != "" {
-		log.Debugf("writing data to command stdin: %s", stdin)
+		log.Debugf("%s: writing data to command stdin: %s", h.Address, stdin)
 		go func() {
 			defer stdinPipe.Close()
 			io.WriteString(stdinPipe, stdin)


### PR DESCRIPTION
```
DEBU[0143] executing command: sudo systemctl enable --now docker
```

==> 

```
DEBU[0143] 192.168.1.1: executing command: sudo systemctl enable --now docker
```

Helps to see which host the command was run on.
