### PR TITLE
Add links into app help text

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ GETTING STARTED:
     https://github.com/Mirantis/launchpad/blob/master/docs/getting-started.md
 
 SUPPORT:
-    https://github.com/mirantis/launchpad/issues
+    https://github.com/Mirantis/launchpad/issues
 `, cli.AppHelpTemplate)
 
 	app := &cli.App{


### PR DESCRIPTION
Now outputs:

```
NAME:
   launchpad - Mirantis Launchpad

USAGE:
   main [global options] command [command options] [arguments...]

COMMANDS:
   apply            Apply a cluster configuration
   register         Register a user
   download-bundle  Download a client bundle
   version
   help, h          Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --debug, -d  Enable debug logging (default: false) [$DEBUG]
   --help, -h   show help (default: false)

GETTING STARTED:
    https://github.com/mirantis/launchpad/blob/master/docs/getting-started.md

SUPPORT:
    https://github.com/mirantis/launchpad/issues
```
