### PR TITLE
Move homedir expansion to happen after unmarshal

### DIFF
--- a/pkg/apis/v1beta1/hosts.go
+++ b/pkg/apis/v1beta1/hosts.go
@@ -60,12 +60,14 @@ type Host struct {
 // UnmarshalYAML sets in some sane defaults when unmarshaling the data from yaml
 func (h *Host) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	defaults.Set(h)
-	// Need to expand possible ~... paths so validation will pass
-	h.SSHKeyPath, _ = homedir.Expand(h.SSHKeyPath)
+
 	type plain Host
 	if err := unmarshal((*plain)(h)); err != nil {
 		return err
 	}
+
+	// Need to expand possible ~... paths so validation will pass
+	h.SSHKeyPath, _ = homedir.Expand(h.SSHKeyPath)
 
 	return nil
 }


### PR DESCRIPTION
The homedir expansion was only performed for the default values because it happened before the YAML unmarshal.

