### PR TITLE
Provide credentials via stdin

### DIFF
--- a/cmd/download_bundle.go
+++ b/cmd/download_bundle.go
@@ -28,10 +28,6 @@ func NewDownloadBundleCommand() *cli.Command {
 				Usage:   "Password",
 				Aliases: []string{"p"},
 			},
-			&cli.BoolFlag{
-				Name:  "password-stdin",
-				Usage: "Provide password via stdin",
-			},
 			&cli.StringFlag{
 				Name:    "config",
 				Usage:   "Path to cluster config yaml",
@@ -60,7 +56,7 @@ func resolveCredentials(ctx *cli.Context) (username, password string) {
 		username = readUsernameFrom(os.Stdin)
 	}
 	password = ctx.String("password")
-	if ctx.Bool("password-stdin") || password == "" {
+	if password == "" {
 		password = readPasswordFrom(os.Stdin)
 	}
 	return username, password


### PR DESCRIPTION
This turned out to be trivial, so I made the username to be providable the same way
## Manual verification
```sh
$ go run main.go download-bundle -c examples/footloose/cluster.yaml
Username: admin
Password: 
DEBU[0004] opened config file from /Users/antonsankov/go/src/github.com/Mirantis/mcc/examples/footloose/cluster.yaml 
DEBU[0008] Writing out bundle to /Users/antonsankov/.mirantis-launchpad/cluster/mcc-ucp/bundle/admin 
INFO[0009] Succesfully wrote client bundle to /Users/antonsankov/.mirantis-launchpad/cluster/mcc-ucp/bundle/admin 

$ go run main.go download-bundle --username admin -c examples/footloose/cluster.yaml
Password: 
DEBU[0002] opened config file from /Users/antonsankov/go/src/github.com/Mirantis/mcc/examples/footloose/cluster.yaml 
DEBU[0008] Writing out bundle to /Users/antonsankov/.mirantis-launchpad/cluster/mcc-ucp/bundle/admin 
INFO[0008] Succesfully wrote client bundle to /Users/antonsankov/.mirantis-launchpad/cluster/mcc-ucp/bundle/admin 

$ go run main.go download-bundle --username admin --password-stdin -c examples/footloose/cluster.yaml
Password: 
DEBU[0003] opened config file from /Users/antonsankov/go/src/github.com/Mirantis/mcc/examples/footloose/cluster.yaml 
DEBU[0009] Writing out bundle to /Users/antonsankov/.mirantis-launchpad/cluster/mcc-ucp/bundle/admin 
INFO[0009] Succesfully wrote client bundle to /Users/antonsankov/.mirantis-launchpad/cluster/mcc-ucp/bundle/admin 

$ go run main.go download-bundle --username admin --password orcaorcaorca -c examples/footloose/cluster.yaml
DEBU[0000] opened config file from /Users/antonsankov/go/src/github.com/Mirantis/mcc/examples/footloose/cluster.yaml 
DEBU[0006] Writing out bundle to /Users/antonsankov/.mirantis-launchpad/cluster/mcc-ucp/bundle/admin 
INFO[0007] Succesfully wrote client bundle to /Users/antonsankov/.mirantis-launchpad/cluster/mcc-ucp/bundle/admin
```