### PR TITLE
Add init sub-command

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/Mirantis/mcc/pkg/constant"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/Mirantis/mcc/pkg/analytics"
+	api "github.com/Mirantis/mcc/pkg/apis/v1beta1"
+	"github.com/urfave/cli/v2"
+)
+
+// NewInitCommand creates new init command to be called from cli
+func NewInitCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "init",
+		Usage: "Initialize cluster.yaml file",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "kind",
+				Usage:   "What kind of cluster definition we'll create",
+				Aliases: []string{"k"},
+				Value:   "UCP",
+				Hidden:  true, // We don't support anything else than UCP for now
+			},
+		},
+		Action: func(ctx *cli.Context) error {
+
+			clusterConfig := api.ClusterConfig{
+				APIVersion: "launchpad.mirantis.com/v1beta1",
+				Kind:       "UCP",
+				Metadata: &api.ClusterMeta{
+					Name: "my-ucp-cluster",
+				},
+				Spec: &api.ClusterSpec{
+					Engine: api.EngineConfig{
+						Version: constant.EngineVersion,
+					},
+					Ucp: api.UcpConfig{
+						Version: constant.UCPVersion,
+					},
+					Hosts: []*api.Host{
+						&api.Host{
+							Address:    "1.2.3.4",
+							Role:       "manager",
+							SSHPort:    22,
+							SSHKeyPath: "~/.ssh/id_rsa",
+							User:       "root",
+						},
+						&api.Host{
+							Address:    "4.5.6.7",
+							Role:       "worker",
+							SSHPort:    22,
+							SSHKeyPath: "~/.ssh/id_rsa",
+							User:       "root",
+						},
+					},
+				},
+			}
+
+			encoder := yaml.NewEncoder(os.Stdout)
+			err := encoder.Encode(clusterConfig)
+
+			if err != nil {
+				analytics.TrackEvent("Cluster Init Failed", nil)
+			} else {
+				analytics.TrackEvent("Cluster Init Completed", nil)
+			}
+			return err
+		},
+	}
+}

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 			cmd.RegisterCommand(),
 			cmd.NewDownloadBundleCommand(),
 			cmd.NewResetCommand(),
+			cmd.NewInitCommand(),
 			versionCmd,
 		},
 	}

--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -11,8 +11,8 @@ type ClusterConfig struct {
 	Kind             string       `yaml:"kind" validate:"eq=UCP"`
 	Metadata         *ClusterMeta `yaml:"metadata"`
 	Spec             *ClusterSpec `yaml:"spec"`
-	ManagerJoinToken string
-	WorkerJoinToken  string
+	ManagerJoinToken string       `yaml:"-"`
+	WorkerJoinToken  string       `yaml:"-"`
 }
 
 // UnmarshalYAML sets in some sane defaults when unmarshaling the data from yaml

--- a/pkg/apis/v1beta1/engine_config.go
+++ b/pkg/apis/v1beta1/engine_config.go
@@ -7,9 +7,9 @@ import (
 // EngineConfig holds the engine installation specific options
 type EngineConfig struct {
 	Version    string `yaml:"version"`
-	RepoURL    string `yaml:"repoUrl"`
-	InstallURL string `yaml:"installURL"`
-	Channel    string `yaml:"channel"`
+	RepoURL    string `yaml:"repoUrl,omitempty"`
+	InstallURL string `yaml:"installURL,omitempty"`
+	Channel    string `yaml:"channel,omitempty"`
 }
 
 // UnmarshalYAML puts in sane defaults when unmarshaling from yaml

--- a/pkg/apis/v1beta1/hosts.go
+++ b/pkg/apis/v1beta1/hosts.go
@@ -44,15 +44,15 @@ type Hosts []*Host
 
 // Host contains all the needed details to work with hosts
 type Host struct {
-	Address          string   `yaml:"address" validate:"required,hostname|ip"`
-	User             string   `yaml:"user" validate:"omitempty,gt=2" default:"root"`
-	SSHPort          int      `yaml:"sshPort" default:"22" validate:"gt=0,lte=65535"`
-	SSHKeyPath       string   `yaml:"sshKeyPath" validate:"file" default:"~/.ssh/id_rsa"`
-	Role             string   `yaml:"role" validate:"oneof=manager worker"`
-	ExtraArgs        []string `yaml:"extraArgs"`
-	PrivateInterface string   `yaml:"privateInterface" default:"eth0" validate:"gt=2"`
-	Metadata         *HostMetadata
-	Configurer       HostConfigurer
+	Address          string `yaml:"address" validate:"required,hostname|ip"`
+	User             string `yaml:"user" validate:"omitempty,gt=2" default:"root"`
+	SSHPort          int    `yaml:"sshPort" default:"22" validate:"gt=0,lte=65535"`
+	SSHKeyPath       string `yaml:"sshKeyPath" validate:"file" default:"~/.ssh/id_rsa"`
+	Role             string `yaml:"role" validate:"oneof=manager worker"`
+	PrivateInterface string `yaml:"privateInterface,omitempty" default:"eth0" validate:"gt=2"`
+
+	Metadata   *HostMetadata  `yaml:"-"`
+	Configurer HostConfigurer `yaml:"-"`
 
 	sshClient *ssh.Client
 }

--- a/pkg/apis/v1beta1/ucp_config.go
+++ b/pkg/apis/v1beta1/ucp_config.go
@@ -11,13 +11,13 @@ import (
 // UcpConfig has all the bits needed to configure UCP during installation
 type UcpConfig struct {
 	Version         string   `yaml:"version"`
-	ImageRepo       string   `yaml:"imageRepo"`
-	InstallFlags    []string `yaml:"installFlags,flow"`
-	ConfigFile      string   `yaml:"configFile" validate:"omitempty,file"`
-	ConfigData      string   `yaml:"configData"`
-	LicenseFilePath string   `yaml:"licenseFilePath" validate:"omitempty,file"`
+	ImageRepo       string   `yaml:"imageRepo,omitempty"`
+	InstallFlags    []string `yaml:"installFlags,omitempty,flow"`
+	ConfigFile      string   `yaml:"configFile,omitempty" validate:"omitempty,file"`
+	ConfigData      string   `yaml:"configData,omitempty"`
+	LicenseFilePath string   `yaml:"licenseFilePath,omitempty" validate:"omitempty,file"`
 
-	Metadata *UcpMetadata
+	Metadata *UcpMetadata `yaml:"-"`
 }
 
 // UcpMetadata has the "runtime" discovered metadata of already existing installation.


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

```
$ go run main.go init
apiVersion: launchpad.mirantis.com/v1beta1
kind: UCP
metadata:
  name: my-ucp-cluster
spec:
  hosts:
  - address: 1.2.3.4
    user: root
    sshPort: 22
    sshKeyPath: ~/.ssh/id_rsa
    role: manager
  - address: 4.5.6.7
    user: root
    sshPort: 22
    sshKeyPath: ~/.ssh/id_rsa
    role: worker
  ucp:
    version: 3.3.0-rc1
  engine:
    version: 19.03.8-rc3
```

User can then direct that into file or copy-pasta it into editor.