### PR TITLE
Bring back file debug logging

### DIFF
--- a/pkg/apis/v1beta1/cluster.go
+++ b/pkg/apis/v1beta1/cluster.go
@@ -20,7 +20,7 @@ func (c *ClusterConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type rawClusterConfig ClusterConfig
 	raw := rawClusterConfig{
 		Metadata: &ClusterMeta{
-			Name: "mcc-ucp",
+			Name: "launchpad-ucp",
 		},
 		Spec: &ClusterSpec{},
 	}

--- a/pkg/cmd/apply/apply.go
+++ b/pkg/cmd/apply/apply.go
@@ -4,14 +4,18 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/Mirantis/mcc/pkg/analytics"
 	"github.com/Mirantis/mcc/pkg/config"
+	"github.com/Mirantis/mcc/pkg/constant"
 	"github.com/Mirantis/mcc/pkg/phase"
 	"github.com/Mirantis/mcc/pkg/util"
 	"github.com/Mirantis/mcc/version"
 	"github.com/mattn/go-isatty"
+	"github.com/mitchellh/go-homedir"
 
+	mcclog "github.com/Mirantis/mcc/pkg/log"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -38,7 +42,11 @@ func Apply(configFile string) error {
 		os.Stdout.WriteString(fmt.Sprintf("   Mirantis Launchpad (c) 2020 Mirantis, Inc.                          v%s\n\n", version.Version))
 	}
 
-	log.Debugf("loaded cluster cfg: %+v", clusterConfig)
+	// Add logger to dump all log levels to file
+	err = addFileLogger(clusterConfig.Metadata.Name)
+	if err != nil {
+		return err
+	}
 
 	phaseManager := phase.NewManager(&clusterConfig)
 	phaseManager.AddPhase(&phase.Connect{})
@@ -81,5 +89,30 @@ func Apply(configFile string) error {
 	ucpInstanceID := fmt.Sprintf("%x", sha1.Sum([]byte(clusterID)))
 	props["ucp_instance_id"] = ucpInstanceID
 	analytics.TrackEvent("Cluster Installed", props)
+	return nil
+}
+
+const fileMode = 0700
+
+func addFileLogger(clusterName string) error {
+	home, err := homedir.Dir()
+	if err != nil {
+		return err
+	}
+
+	clusterDir := path.Join(home, constant.StateBaseDir, "cluster", clusterName)
+	if err := util.EnsureDir(clusterDir); err != nil {
+		return fmt.Errorf("error while creating directory for apply logs: %w", err)
+	}
+	logFileName := path.Join(clusterDir, "apply.log")
+	logFile, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileMode)
+
+	if err != nil {
+		return fmt.Errorf("Failed to create apply log at %s: %s", logFileName, err.Error())
+	}
+
+	// Send all logs to named file, this ensures we always have debug logs also available when needed
+	log.AddHook(mcclog.NewFileHook(logFile))
+
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

#80 took the file logging stuff away by accident. The file logger was initialized as part of the state stuff as that created the base state dir for the cluster.

Now moved the same logic into `apply.Apply`