### PR TITLE
Add `socat` to packages installed

### DIFF
--- a/pkg/configurer/enterpriselinux/el.go
+++ b/pkg/configurer/enterpriselinux/el.go
@@ -29,7 +29,7 @@ func (c *Configurer) InstallBasePackages() error {
 	if err != nil {
 		return err
 	}
-	return c.Host.Exec("sudo yum install -y curl")
+	return c.Host.Exec("sudo yum install -y curl socat")
 }
 
 // UninstallEngine uninstalls docker-ee engine

--- a/pkg/configurer/ubuntu/ubuntu.go
+++ b/pkg/configurer/ubuntu/ubuntu.go
@@ -17,7 +17,7 @@ func (c *Configurer) InstallBasePackages() error {
 	if err != nil {
 		return err
 	}
-	return c.Host.Exec("sudo apt-get update && sudo apt-get install -y curl apt-utils")
+	return c.Host.Exec("sudo apt-get update && sudo apt-get install -y curl apt-utils socat")
 }
 
 // UninstallEngine uninstalls docker-ee engine


### PR DESCRIPTION
in `HostConfigurer::InstallBasePackages`

## Verifications
Smoke tests for the two OSs pass, so installation was successful. 

manually verified `kubectl port-forward` works by completing this exercise: https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/