### PR TITLE
Add warning to disable Docker Desktop Kubernetes

### DIFF
--- a/examples/footloose/README.md
+++ b/examples/footloose/README.md
@@ -7,3 +7,8 @@
 1. `footloose create`
 2. `launchpad apply`
 3. Profit :)
+
+## Note
+If you are using Docker Desktop make sure that the Kubernetes feature is OFF.
+When `footloose` spins up your UCP cluster it will automatically forward port 6443 on your host to port 6443 on your UCP manager.
+If you are running Kubernetes locally via Docker Desktop this will fail, because port 6443 is already in use.


### PR DESCRIPTION
when working with local footloose cluster

Signed-off-by: asankov <a.sankov96@gmail.com>

I've ran into this once and took me a while to realize what was wrong. So I think it's better to have it documented for the next one who stumbles upon this.