### PR TITLE
Install iptables on Centos

### DIFF
--- a/pkg/configurer/centos/centos.go
+++ b/pkg/configurer/centos/centos.go
@@ -11,6 +11,15 @@ type Configurer struct {
 	enterpriselinux.Configurer
 }
 
+// InstallBasePackages install all the needed base packages on the host
+func (c *Configurer) InstallBasePackages() error {
+	err := c.FixContainerizedHost()
+	if err != nil {
+		return err
+	}
+	return c.Host.Exec("sudo yum install -y curl socat iptables")
+}
+
 func resolveCentosConfigurer(h *api.Host) api.HostConfigurer {
 	if h.Metadata.Os.ID == "centos" {
 		return &Configurer{


### PR DESCRIPTION
Docker fails to start on CentOS 8 because there's no `iptables`.

