### PR TITLE
Enable releasing prereleases to the public repo

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -55,6 +55,7 @@ done
 
 # Release to the public repo
 ./github-release release \
+  $releaseopt \
   --draft \
   --user Mirantis \
   --repo launchpad \


### PR DESCRIPTION
For 0.12.0-alpha I had to create the release and upload the binaries manually.

