### PR TITLE
Make WriteFile return an error on empty content or path

### DIFF
--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -176,6 +176,14 @@ func (c *LinuxConfigurer) AuthenticateDocker(user, pass, imageRepo string) error
 
 // WriteFile writes file to host with given contents. Do not use for large files.
 func (c *LinuxConfigurer) WriteFile(path string, data string, permissions string) error {
+	if data == "" {
+		return fmt.Errorf("empty content in WriteFile to %s", path)
+	}
+
+	if path == "" {
+		return fmt.Errorf("empty path in WriteFile")
+	}
+
 	tempFile, err := c.Host.ExecWithOutput("mktemp")
 	if err != nil {
 		return err

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -126,6 +126,13 @@ func (c *WindowsConfigurer) AuthenticateDocker(user, pass, imageRepo string) err
 // WriteFile writes file to host with given contents. Do not use for large files.
 // The permissions argument is ignored on windows.
 func (c *WindowsConfigurer) WriteFile(path string, data string, permissions string) error {
+	if data == "" {
+		return fmt.Errorf("empty content in WriteFile to %s", path)
+	}
+
+	if path == "" {
+		return fmt.Errorf("empty path in WriteFile")
+	}
 
 	tempFile, err := c.Host.ExecWithOutput("powershell -Command \"New-TemporaryFile | Write-Host\"")
 	if err != nil {


### PR DESCRIPTION
An empty string will make the writer hang indefinitely while waiting for input, causing confusion while developing.

If we need to create an empty file in the future, we can add `Touch` or alter the `WriteFile` to allow that.
