### PR TITLE
Use sudo when creating docker systemd directory

### DIFF
--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -251,7 +251,7 @@ func (c *LinuxConfigurer) ConfigureDockerProxy() error {
 	dir := "/etc/systemd/system/docker.service.d"
 	cfg := path.Join(dir, "http-proxy.conf")
 
-	err := c.Host.ExecCmd(fmt.Sprintf("mkdir -p %s", dir), "", false, false)
+	err := c.Host.ExecCmd(fmt.Sprintf("sudo mkdir -p %s", dir), "", false, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://mirantis.jira.com/browse/ENGORC-7723

The `mkdir` for `/etc/systemd/system/docker.service.d` was not using sudo and thus failed.

