### PR TITLE
Fix replacing lines in files such as /etc/environment

### DIFF
--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -204,6 +204,7 @@ func (c *LinuxConfigurer) FileExist(path string) bool {
 }
 
 // LineIntoFile tries to find a matching line in a file and replace it with a new entry
+// TODO refactor this into go because it's too magical.
 func (c *LinuxConfigurer) LineIntoFile(path, matcher, newLine string) error {
 	if c.FileExist(path) {
 		err := c.Host.ExecCmd(fmt.Sprintf(`file=%s; match=%s; line=%s; sudo grep -q "${match}" "$file" && sudo sed -i "/${match}/c ${line}" "$file" || (echo "$line" | sudo tee -a "$file" > /dev/null)`, escape.Quote(path), escape.Quote(matcher), escape.Quote(newLine)), "", false, true)


### PR DESCRIPTION
Fixes https://mirantis.jira.com/browse/ENGORC-7746

The shell-snippet to replace a line in a file caused the line to be mangled further on each run if the value had special characters, for example `REGISTRY_PASSWORD=abc&def` would eventually create something like:

```
REGISTRY_PASSWORD=abcREGISTRY_PASSWORD=abcREGISTRY_PASSWORD=abc
```

This PR fixes that problem, also the command has been marked as sensitive, because it would potentially display passwords.

`cluster.yaml` : 

```yaml
apiVersion: "launchpad.mirantis.com/v1beta2"
kind: UCP
spec:
  hosts:
    - address: "127.0.0.1"
      role: "worker"
      environment:
        FOO_FOOFOO: bbb"abc&def]ghi
```

Before first run:

```
$ footloose ssh root@worker0 cat /etc/environment
PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
```

After first run:

```
$ footloose ssh root@worker0 cat /etc/environment
PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
FOO_FOOFOO=bbb"abc&def]ghi
```

After second run:

```
$ footloose ssh root@worker0 cat /etc/environment
PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
FOO_FOOFOO=bbb"abc&def]ghi
```

Prefixing the value with `ccc'` in `cluster.yaml` and after the third run:

```
$ footloose ssh root@worker0 cat /etc/environment
PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
FOO_FOOFOO=ccc'bbb"abc&def]ghi
```

Seems to work as expected. With the original snippet the line was getting messed up.
