### PR TITLE
[ENGDTR-1910] More webURL fixes, remove LicenseFilePath for DTR

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -23,7 +23,7 @@ func NewApplyCommand() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  "prune",
-				Usage: "Automatically remove nodes that are not anymore part of cluster config yaml",
+				Usage: "Automatically remove nodes that are no longer a part of cluster config yaml",
 				Value: false,
 			},
 		},

--- a/pkg/apis/v1beta3/cluster_spec.go
+++ b/pkg/apis/v1beta3/cluster_spec.go
@@ -66,9 +66,9 @@ func (c *ClusterSpec) WebURLs() *WebUrls {
 	}
 
 	ucpAddress = fmt.Sprintf("https://%s", ucpAddress)
-	var dtrAddress string
-	if len(c.Dtrs()) > 0 {
-		dtrAddress = c.buildDtrWebURL()
+	dtrAddress := c.dtrWebURL()
+	if dtrAddress != "" {
+		dtrAddress = fmt.Sprintf("https://%s", c.dtrWebURL())
 	}
 
 	return &WebUrls{
@@ -143,28 +143,26 @@ func IsCustomImageRepo(imageRepo string) bool {
 	return imageRepo != constant.ImageRepo
 }
 
-// buildDtrWebURL returns a URL based on the DtrLeaderAddress or whether the
+// dtrWebURL returns an address based on the DtrLeaderAddress or whether the
 // user has provided the --dtr-external-url flag
-func (c *ClusterSpec) buildDtrWebURL() string {
+func (c *ClusterSpec) dtrWebURL() string {
 	// Default to using the --dtr-external-url if it's set
 	dtrAddress := util.GetInstallFlagValue(c.Dtr.InstallFlags, "--dtr-external-url")
 	if dtrAddress != "" {
-		return fmt.Sprintf("https://%s", dtrAddress)
-	}
-	// If for some reason we don't have DTR metadata return the
-	// first DTR roles address
-	if c.Dtr.Metadata == nil {
-		for _, h := range c.Hosts {
-			if h.Role == "dtr" {
-
-				return fmt.Sprintf("https://%s", h.Address)
-			}
-		}
+		return dtrAddress
 	}
 	// Otherwise, use DtrLeaderAddress
-	if c.Dtr.Metadata.DtrLeaderAddress != "" {
-		return fmt.Sprintf("https://%s", c.Dtr.Metadata.DtrLeaderAddress)
+	if c.Dtr.Metadata != nil {
+		if c.Dtr.Metadata.DtrLeaderAddress != "" {
+			return c.Dtr.Metadata.DtrLeaderAddress
+		}
 	}
-	// If we still can't find a host, return nothing
-	return ""
+	// If we still can't find an address iterate the host roles for a value
+	for _, h := range c.Hosts {
+		if h.Role == "dtr" {
+			dtrAddress = h.Address
+			break
+		}
+	}
+	return dtrAddress
 }

--- a/pkg/apis/v1beta3/cluster_spec_test.go
+++ b/pkg/apis/v1beta3/cluster_spec_test.go
@@ -89,6 +89,22 @@ func TestUCPClusterSpecWebURLWithNoDTRMetadata(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
+func TestUCPClusterSpecWebURLWithNoDTRHostRoleButConfig(t *testing.T) {
+	spec := ClusterSpec{
+		Hosts: []*Host{
+			{Address: "192.168.1.2", Role: "manager"},
+		},
+		Ucp: UcpConfig{},
+		Dtr: DtrConfig{},
+	}
+	expected := &WebUrls{
+		Ucp: "https://192.168.1.2",
+		Dtr: "",
+	}
+	actual := spec.WebURLs()
+	require.Equal(t, expected, actual)
+}
+
 func TestUCPClusterSpecWebURLWithDTRWebURLWithoutExternalURL(t *testing.T) {
 	spec := ClusterSpec{
 		Hosts: []*Host{

--- a/pkg/apis/v1beta3/dtr_config.go
+++ b/pkg/apis/v1beta3/dtr_config.go
@@ -8,11 +8,10 @@ import (
 
 // DtrConfig has all the bits needed to configure DTR during installation
 type DtrConfig struct {
-	Version         string   `yaml:"version"`
-	ImageRepo       string   `yaml:"imageRepo"`
-	InstallFlags    []string `yaml:"installFlags,flow"`
-	ReplicaConfig   string   `yaml:"replicaConfig,omitempty"  default:"random"`
-	LicenseFilePath string   `yaml:"licenseFilePath,omitempty" validate:"omitempty,file"`
+	Version       string   `yaml:"version"`
+	ImageRepo     string   `yaml:"imageRepo"`
+	InstallFlags  []string `yaml:"installFlags,flow"`
+	ReplicaConfig string   `yaml:"replicaConfig,omitempty"  default:"random"`
 
 	Metadata *DtrMetadata
 }

--- a/pkg/phase/info.go
+++ b/pkg/phase/info.go
@@ -18,9 +18,7 @@ func (p *Info) Run(config *api.ClusterConfig) error {
 	urls := config.Spec.WebURLs()
 	log.Info("Cluster is now configured.  You can access your admin UIs at:\n")
 	log.Infof("UCP cluster admin UI: %s", urls.Ucp)
-	// If the DTR URL is blank, it will still return a https://%s string, so
-	// check for anything other than that
-	if urls.Dtr != "https://" {
+	if urls.Dtr != "" {
 		log.Infof("DTR cluster admin UI: %s", urls.Dtr)
 	}
 	log.Infof("You can also download the admin client bundle with the following command: launchpad download-bundle --username <username> --password <password>")

--- a/pkg/phase/install_dtr.go
+++ b/pkg/phase/install_dtr.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/Mirantis/mcc/pkg/dtr"
-	"github.com/Mirantis/mcc/pkg/util"
 	log "github.com/sirupsen/logrus"
 
 	api "github.com/Mirantis/mcc/pkg/apis/v1beta3"
@@ -55,15 +54,6 @@ func (p *InstallDtr) Run(config *api.ClusterConfig) (err error) {
 	if config.Spec.Dtr.ReplicaConfig == "sequential" {
 		log.Debugf("Configuring DTR replica ids to be sequential")
 		installFlags = append(installFlags, fmt.Sprintf("--replica-id %s", dtr.SequentialReplicaID(1)))
-	}
-
-	if licenseFilePath := config.Spec.Dtr.LicenseFilePath; licenseFilePath != "" {
-		log.Debugf("Installing DTR with licenseFilePath: %s", licenseFilePath)
-		licenseFlag, err := util.SetupLicenseFile(config.Spec.Dtr.LicenseFilePath)
-		if err != nil {
-			return fmt.Errorf("error while reading license file %s: %v", licenseFilePath, err)
-		}
-		installFlags = append(installFlags, licenseFlag)
 	}
 
 	// Configure the ucpFlags from existing UcpConfig

--- a/test/cluster.yaml.tpl
+++ b/test/cluster.yaml.tpl
@@ -22,7 +22,6 @@ spec:
     configData: |-
       [scheduling_configuration]
         default_node_orchestrator = "kubernetes"
-        enable_admin_ucp_scheduling = true
     installFlags:
       - --admin-username=admin
       - --admin-password=orcaorcaorca


### PR DESCRIPTION
This patch is a follow-up to #147 to fix:
* Issues with the webURL's not being printed reliably at the end of a `launchpad` run
* Remove the `LicenseFilePath` and associated code around DTR licensing since DTR now appropriately acquires it's license from UCP (will re-add when standalone arrives).
* Fixes some typos