### PR TITLE
Upgrade engine also on DTR nodes

### DIFF
--- a/pkg/phase/install_engine.go
+++ b/pkg/phase/install_engine.go
@@ -67,7 +67,7 @@ func (p *InstallEngine) upgradeEngines(c *api.ClusterConfig) error {
 	}
 
 	workers := []*api.Host{}
-	for _, h := range c.Spec.Workers() {
+	for _, h := range c.Spec.WorkersAndDtrs() {
 		if h.Metadata.EngineVersion != "" && h.Metadata.EngineVersion != c.Spec.Engine.Version {
 			workers = append(workers, h)
 		}


### PR DESCRIPTION
Fixes https://mirantis.jira.com/browse/ENGORC-7826

Engine upgrade was only being performed on managers and workers, but missed the DTR nodes.
