### PR TITLE
Figure out UCP version from image name, not labels

### DIFF
--- a/pkg/ucp/ucp.go
+++ b/pkg/ucp/ucp.go
@@ -33,7 +33,7 @@ type Credentials struct {
 // Currently we only need to know the existing version and whether UCP is installed or not.
 // In future we probably need more.
 func CollectUcpFacts(swarmLeader *api.Host, ucpMeta *api.UcpMetadata) error {
-	output, err := swarmLeader.ExecWithOutput(swarmLeader.Configurer.DockerCommandf(`inspect --format '{{.Image}}' ucp-proxy`))
+	output, err := swarmLeader.ExecWithOutput(swarmLeader.Configurer.DockerCommandf(`inspect --format '{{.Config.Image}}' ucp-proxy`))
 	if err != nil {
 		if strings.Contains(output, "No such object") {
 			ucpMeta.Installed = false


### PR DESCRIPTION
Fixes https://mirantis.jira.com/browse/ENGORC-7859

The current version check reads the value from the ucp-proxy image labels. This changes the version to be read from the image tag (mirantis/ucp-proxy:XXXX)

The labels say "3.3.3" even for "3.3.3-prerelease" versions, so it breaks the downgrade check when re-applying and the check to see if running the upgrade utility is necessary.

This can now be seen in the output:
```
INFO[0000] 127.0.0.1: UCP has version 3.4.0-tp6    
```
