### PR TITLE
PRODENG-681 update DTR and Engine default versions for 08/2020

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -8,9 +8,9 @@ const (
 	// UCPVersion is the default UCP version to use
 	UCPVersion = "3.3.2"
 	// DTRVersion is the default DTR version to use
-	DTRVersion = "2.8.1"
+	DTRVersion = "2.8.2"
 	// EngineVersion is the default engine version
-	EngineVersion = "19.03.8"
+	EngineVersion = "19.03.12"
 	// EngineChannel is the default engine channel
 	EngineChannel = "stable"
 	// EngineRepoURL is the default engine repo


### PR DESCRIPTION
- DTR update to 2.8.2
- Engine update to 19.03.12

both are as per 08/2020 patch cycle

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>