### PR TITLE
Make environment update happen before base package installation

### DIFF
--- a/pkg/phase/prepare_host.go
+++ b/pkg/phase/prepare_host.go
@@ -19,12 +19,12 @@ func (p *PrepareHost) Title() string {
 
 // Run does all the prep work on the hosts in parallel
 func (p *PrepareHost) Run() error {
-	err := runParallelOnHosts(p.config.Spec.Hosts, p.config, p.installBasePackages)
+	err := runParallelOnHosts(p.config.Spec.Hosts, p.config, p.updateEnvironment)
 	if err != nil {
 		return err
 	}
 
-	err = runParallelOnHosts(p.config.Spec.Hosts, p.config, p.updateEnvironment)
+	err = runParallelOnHosts(p.config.Spec.Hosts, p.config, p.installBasePackages)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://github.com/Mirantis/launchpad/issues/48
Fixes https://mirantis.jira.com/browse/ENGORC-7874

The environment update was done after base package install, making `HTTP_PROXY` etc not have effect on the package installation. This PR flips the order.
