### PR TITLE
Upgrade default UCP to 3.3.3 and DTR to 2.8.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,21 +50,6 @@ pipeline {
             sh "make smoke-apply-test CONFIG_TEMPLATE=v1beta1_launchpad.yaml.tpl LINUX_IMAGE=quay.io/footloose/ubuntu18.04"
           }
         }
-        stage("Ubuntu 18.04: apply 3.3.3-tp10") {
-          agent {
-            node {
-              label 'amd64 && ubuntu-1804 && overlay2 && big'
-            }
-          }
-          environment {
-            UCP_IMAGE_REPO = "docker.io/dockereng"
-            UCP_VERSION = "3.3.3-tp10"
-            REGISTRY_CREDS = credentials("dockerbuildbot-index.docker.io")
-          }
-          steps {
-            sh "make smoke-apply-test LINUX_IMAGE=quay.io/footloose/ubuntu18.04"
-          }
-        }
         stage("CentOS 7: apply") {
           agent {
               node {
@@ -194,18 +179,16 @@ pipeline {
                 sh "make smoke-test"
               }
             }
-            stage("Upgrade UCP3.3 DTR2.8 ENG19.03.11") {
+            stage("Upgrade UCP3.3 DTR2.8 ENG19.03.12") {
               environment {
-                UCP_IMAGE_REPO = "docker.io/dockereng"
                 LINUX_IMAGE = "quay.io/footloose/ubuntu18.04"
                 FOOTLOOSE_TEMPLATE = "footloose-dtr.yaml.tpl"
                 CONFIG_TEMPLATE = "launchpad-dtr.yaml.tpl"
-                UCP_VERSION = "3.3.3-tp10"
+                UCP_VERSION = "3.3.3"
                 REGISTRY_CREDS = credentials("dockerbuildbot-index.docker.io")
                 IMAGE_REPO = "docker.io/mirantis"
-                DTR_VERSION = "2.8.2"
-                DTR_IMAGE_REPO = "docker.io/mirantis"
-                ENGINE_VERSION = "19.03.11"
+                DTR_VERSION = "2.8.3"
+                ENGINE_VERSION = "19.03.12"
                 REUSE_CLUSTER = "true"
                 PRESERVE_CLUSTER = "true"
               }

--- a/examples/footloose/launchpad.yaml
+++ b/examples/footloose/launchpad.yaml
@@ -6,7 +6,7 @@ spec:
       ssh:
         port: 9022
         user: "root"
-      role: "manager"
+      role: "worker"
       engineConfig: &linuxEngineConfig
         debug: true
         log-opts:

--- a/pkg/cmd/apply/apply.go
+++ b/pkg/cmd/apply/apply.go
@@ -43,6 +43,7 @@ func Apply(configFile string, prune, force bool) error {
 		return err
 	}
 
+	log.Debugf("validating configuration")
 	if err = config.Validate(&clusterConfig); err != nil {
 		return err
 	}

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -6,9 +6,9 @@ const (
 	// ImageRepoLegacy is the default image repo to use for older versions
 	ImageRepoLegacy = "docker.io/docker"
 	// UCPVersion is the default UCP version to use
-	UCPVersion = "3.3.2"
+	UCPVersion = "3.3.3"
 	// DTRVersion is the default DTR version to use
-	DTRVersion = "2.8.2"
+	DTRVersion = "2.8.3"
 	// EngineVersion is the default engine version
 	EngineVersion = "19.03.12"
 	// EngineChannel is the default engine channel

--- a/test/smoke.common.sh
+++ b/test/smoke.common.sh
@@ -3,9 +3,9 @@
 FOOTLOOSE_TEMPLATE=${FOOTLOOSE_TEMPLATE:-"footloose.yaml.tpl"}
 CONFIG_TEMPLATE=${CONFIG_TEMPLATE:-"launchpad.yaml.tpl"}
 export LINUX_IMAGE=${LINUX_IMAGE:-"quay.io/footloose/ubuntu18.04"}
-export UCP_VERSION=${UCP_VERSION:-"3.3.2"}
+export UCP_VERSION=${UCP_VERSION:-"3.3.3"}
 export UCP_IMAGE_REPO=${UCP_IMAGE_REPO:-"docker.io/mirantis"}
-export DTR_VERSION=${DTR_VERSION:-"2.8.2"}
+export DTR_VERSION=${DTR_VERSION:-"2.8.3"}
 export DTR_IMAGE_REPO=${DTR_IMAGE_REPO:-"docker.io/mirantis"}
 export ENGINE_VERSION=${ENGINE_VERSION:-"19.03.12"}
 export PRESERVE_CLUSTER=${PRESERVE_CLUSTER:-""}

--- a/test/smoke_upgrade.sh
+++ b/test/smoke_upgrade.sh
@@ -10,10 +10,10 @@ setup
 
 [ "${REUSE_CLUSTER}" = "" ] && ../bin/launchpad --debug apply
 
-export UCP_VERSION=${UCP_UPGRADE_VERSION:-"3.3.2"}
+export UCP_VERSION=${UCP_UPGRADE_VERSION:-"3.3.3"}
 export UCP_IMAGE_REPO=${UCP_UPGRADE_IMAGE_REPO:-"docker.io/mirantis"}
-export ENGINE_VERSION=${ENGINE_UPGRADE_VERSION:-"19.03.8"}
-export DTR_VERSION=${DTR_UPGRADE_VERSION:"2.8.2"}
+export ENGINE_VERSION=${ENGINE_UPGRADE_VERSION:-"19.03.12"}
+export DTR_VERSION=${DTR_UPGRADE_VERSION:"2.8.3"}
 
 generateYaml
 


### PR DESCRIPTION
Removes the 3.3.3-tp smoke test because now it is done in the regular apply.
