### PR TITLE
Fix http-proxy.conf linefeeds

### DIFF
--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -286,7 +286,7 @@ func (c *LinuxConfigurer) ConfigureDockerProxy() error {
 
 	content := "[Service]\n"
 	for k, v := range proxyenvs {
-		content += fmt.Sprintf(`Environment="%s=%s\n"`, escape.Quote(k), escape.Quote(v))
+		content += fmt.Sprintf("Environment=\"%s=%s\"\n", escape.Quote(k), escape.Quote(v))
 	}
 
 	return c.WriteFile(cfg, content, "0600")


### PR DESCRIPTION
Fixes https://github.com/Mirantis/launchpad/issues/49

Go does not output a linefeed for `\n` when the string is inside backticks.

And not only that, the linefeed was in the wrong place anyway: `"%s=%s\n"`.
