### PR TITLE
Try to detect host's private interface automatically

### DIFF
--- a/pkg/api/configurer.go
+++ b/pkg/api/configurer.go
@@ -8,6 +8,7 @@ type HostConfigurer interface {
 	CheckPrivilege() error
 	ResolveHostname() string
 	ResolveLongHostname() string
+	ResolvePrivateInterface() (string, error)
 	ResolveInternalIP() (string, error)
 	IsContainerized() bool
 	SELinuxEnabled() bool

--- a/pkg/api/host.go
+++ b/pkg/api/host.go
@@ -70,7 +70,7 @@ type Hooks struct {
 type Host struct {
 	Address          string            `yaml:"address" validate:"required,hostname|ip"`
 	Role             string            `yaml:"role" validate:"oneof=manager worker dtr"`
-	PrivateInterface string            `yaml:"privateInterface,omitempty" default:"eth0" validate:"gt=2"`
+	PrivateInterface string            `yaml:"privateInterface,omitempty" validate:"omitempty,gt=2"`
 	DaemonConfig     GenericHash       `yaml:"engineConfig,flow,omitempty" default:"{}"`
 	Environment      map[string]string `yaml:"environment,flow,omitempty" default:"{}"`
 	Hooks            *Hooks            `yaml:"hooks,omitempty" default:"{}"`

--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/Mirantis/mcc/pkg/util"
@@ -290,4 +291,19 @@ func (c *LinuxConfigurer) ConfigureDockerProxy() error {
 	}
 
 	return c.WriteFile(cfg, content, "0600")
+}
+
+// ResolvePrivateInterface tries to find a private network interface
+func (c *LinuxConfigurer) ResolvePrivateInterface() (string, error) {
+	output, err := c.Host.ExecWithOutput(`(ip route list scope global | grep -P "\b(172|10|192\.168)\.") || (ip route list | grep -m1 default)`)
+	if err == nil {
+		re := regexp.MustCompile(`\bdev (\w+)`)
+		match := re.FindSubmatch([]byte(output))
+		if len(match) > 0 {
+			return string(match[1]), nil
+		}
+		err = fmt.Errorf("can't find 'dev' in output")
+	}
+
+	return "", fmt.Errorf("failed to detect a private network interface, define the host privateInterface manually (%s)", err.Error())
 }

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -207,3 +207,15 @@ func (c *WindowsConfigurer) CleanupEnvironment() error {
 	}
 	return nil
 }
+
+// ResolvePrivateInterface tries to find a private network interface
+func (c *WindowsConfigurer) ResolvePrivateInterface() (string, error) {
+	output, err := c.Host.ExecWithOutput(`powershell "(Get-NetConnectionProfile -NetworkCategory Private | Select-Object -First 1).InterfaceAlias"`)
+	if err != nil || output == "" {
+		output, err = c.Host.ExecWithOutput(`powershell "(Get-NetConnectionProfile | Select-Object -First 1).InterfaceAlias"`)
+	}
+	if err != nil || output == "" {
+		return "", fmt.Errorf("failed to detect a private network interface, define the host privateInterface manually")
+	}
+	return strings.TrimSpace(output), nil
+}

--- a/pkg/phase/gather_facts.go
+++ b/pkg/phase/gather_facts.go
@@ -119,6 +119,16 @@ func (p *GatherFacts) investigateHost(h *api.Host, c *api.ClusterConfig) error {
 
 	h.Metadata.Hostname = h.Configurer.ResolveHostname()
 	h.Metadata.LongHostname = h.Configurer.ResolveLongHostname()
+
+	if h.PrivateInterface == "" {
+		i, err := h.Configurer.ResolvePrivateInterface()
+		if err != nil {
+			return err
+		}
+		log.Infof("%s: detected private interface %s", h.Address, i)
+		h.PrivateInterface = i
+	}
+
 	a, err := h.Configurer.ResolveInternalIP()
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes https://mirantis.jira.com/browse/ENGORC-7701

For linux, it tries to find an interface from `ip route list scope global` that has an address in 10.0.0.0/8, 172.0.0.0.0/8, 192.168.0.0/16, if that fails, gets the default route interface.

For windows, it uses `Get-NetConnectionProfile` first with `-NetworkCategory Private` and if that fails, without a category.

