### PR TITLE
Sanitize Makefile quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ ifdef TAG_NAME
 endif
 ENVIRONMENT ?= "development"
 LAUNCHPAD_VERSION ?= $(or ${TAG_NAME},dev)
-LD_FLAGS = "-w -X github.com/Mirantis/mcc/version.Environment=$(ENVIRONMENT) -X github.com/Mirantis/mcc/version.GitCommit=$(GIT_COMMIT) -X github.com/Mirantis/mcc/version.Version=$(LAUNCHPAD_VERSION)
-BUILD_FLAGS = -a -tags "netgo static_build" -installsuffix netgo -ldflags $(LD_FLAGS) -extldflags '-static'"
+LD_FLAGS = -s -w -X github.com/Mirantis/mcc/version.Environment=$(ENVIRONMENT) -X github.com/Mirantis/mcc/version.GitCommit=$(GIT_COMMIT) -X github.com/Mirantis/mcc/version.Version=$(LAUNCHPAD_VERSION)
+BUILD_FLAGS = -trimpath -a -tags "netgo static_build" -installsuffix netgo -ldflags "$(LD_FLAGS) -extldflags '-static'"
 ifeq ($(OS),Windows_NT)
        uname_s := "windows"
        TARGET ?= "bin\\launchpad.exe"


### PR DESCRIPTION
The makefile had weird quotes, the closing `"` for the `LDFLAGS` was actually injected in the end of `BUILDFLAGS`.

This also adds the `-trimpath` BUILDFLAG (strip build host filesystem paths from the compiled binary) and the `-s` LDFLAG (Omit the symbol table and debug information from the binary).

