### PR TITLE
Improve self upgrade check latest version resolving

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -96,7 +96,7 @@ func latestTag(timeout time.Duration) string {
 
 	baseMsg := "getting launchpad tag list"
 	log.Debugf(baseMsg)
-	resp, err := client.Get(fmt.Sprintf("https://api.github.com/repos/%s/tags", GitHubRepo))
+	resp, err := client.Get(fmt.Sprintf("https://api.github.com/repos/%s/tags?per_page=20&page=1", GitHubRepo))
 	if err != nil {
 		log.Debugf("%s failed: %s", baseMsg, err.Error())
 		return "" // ignore connection errors


### PR DESCRIPTION
Fixes https://mirantis.jira.com/browse/ENGORC-7888

The github `/latest` api does not return the highest version number, it returns what was tagged last, meaning a patch release like 0.14.1 would be "latest" even when there is already something like 1.5.4 out.

1. List tags
2. Sort tags
3. If current is pre, return absolute latest (the highest version) tag. If current is not pre, return latest non-pre tag.
4. Get release information for that tag  and continue as before.
