### PR TITLE
Don't pull images that already exist

### DIFF
--- a/pkg/api/host.go
+++ b/pkg/api/host.go
@@ -189,6 +189,11 @@ func (h *Host) AuthenticateDocker(imageRepo string) error {
 	return nil
 }
 
+// ImageExist returns true if a docker image exists on the host
+func (h *Host) ImageExist(name string) bool {
+	return h.Exec(h.Configurer.DockerCommandf("image inspect %s --format '{{.ID}}'", name)) == nil
+}
+
 // PullImage pulls the named docker image on the host
 func (h *Host) PullImage(name string) error {
 	output, err := h.ExecWithOutput(h.Configurer.DockerCommandf("pull %s", name))


### PR DESCRIPTION
Checks if images exist before pulling. This may or may not help with @quadespresso 's attempts at `docker load`ing before apply to install in an airgapped environment.
