### PR TITLE
Fix windows docker login password leaking into logs

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -26,7 +26,7 @@ type Options struct {
 func (o *Options) LogCmd(prefix, cmd string) {
 	var msg string
 	if o.LogCommand {
-		msg = fmt.Sprintf("%s: executing `%s`", prefix, cmd)
+		msg = fmt.Sprintf("%s: executing `%s`", prefix, o.Redact(cmd))
 	} else {
 		msg = fmt.Sprintf("%s: executing [REDACTED]", prefix)
 	}


### PR DESCRIPTION
The new "exec" package (for functional exec options) did not properly filter the `executing %s` log line, causing docker hub credentials to leak into logs if running any windows hosts. (the `--password-stdin` does not seem to work there so `-p` is used).
