### PR TITLE
Fix command output being parsed as sprintf template

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -73,13 +73,10 @@ func (o *Options) AddOutput(prefix, s string) {
 		*o.Output += s
 	}
 
-	msg := fmt.Sprintf("%s: %s", prefix, o.Redact(s))
 	if o.StreamOutput {
-		o.LogInfof(msg)
-	} else if o.LogDebug {
-		o.LogDebugf(msg)
+		log.Infof("%s: %s", prefix, o.Redact(s))
 	} else {
-		o.LogDebugf("%s: [REDACTED] (%d bytes)", prefix, len(s))
+		o.LogDebugf("%s: %s", prefix, o.Redact(s))
 	}
 }
 


### PR DESCRIPTION
The new exec package passed the message essentially as-is to `sprintf`, making go try to parrse it as a template, causing this to happen:

```
DEBU 1.2.3.4: executing echo foo%sfoo
DEBU 1.2.3.4: foo%!s(MISSING)foo
```
