### PR TITLE
Add TakesFile: true to config flags

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -16,10 +16,11 @@ func NewApplyCommand() *cli.Command {
 		Usage: "Apply a cluster configuration",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:    "config",
-				Usage:   "Path to cluster config yaml",
-				Aliases: []string{"c"},
-				Value:   "launchpad.yaml",
+				Name:      "config",
+				Usage:     "Path to cluster config yaml",
+				Aliases:   []string{"c"},
+				Value:     "launchpad.yaml",
+				TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:  "prune",

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -32,10 +32,11 @@ func NewDescribeCommand() *cli.Command {
 		ArgsUsage: fmt.Sprintf("<%s>", strings.Join(reports, "|")),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:    "config",
-				Usage:   "Path to cluster config yaml",
-				Aliases: []string{"c"},
-				Value:   "launchpad.yaml",
+				Name:      "config",
+				Usage:     "Path to cluster config yaml",
+				Aliases:   []string{"c"},
+				Value:     "launchpad.yaml",
+				TakesFile: true,
 			},
 		},
 		Action: func(ctx *cli.Context) error {

--- a/cmd/download_bundle.go
+++ b/cmd/download_bundle.go
@@ -29,10 +29,11 @@ func NewDownloadBundleCommand() *cli.Command {
 				Aliases: []string{"p"},
 			},
 			&cli.StringFlag{
-				Name:    "config",
-				Usage:   "Path to cluster config yaml",
-				Aliases: []string{"c"},
-				Value:   "launchpad.yaml",
+				Name:      "config",
+				Usage:     "Path to cluster config yaml",
+				Aliases:   []string{"c"},
+				Value:     "launchpad.yaml",
+				TakesFile: true,
 			},
 		},
 		Action: func(ctx *cli.Context) error {

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -20,10 +20,11 @@ func NewResetCommand() *cli.Command {
 		Usage: "Reset (uninstall) a cluster",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:    "config",
-				Usage:   "Path to cluster config yaml",
-				Aliases: []string{"c"},
-				Value:   "launchpad.yaml",
+				Name:      "config",
+				Usage:     "Path to cluster config yaml",
+				Aliases:   []string{"c"},
+				Value:     "launchpad.yaml",
+				TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:    "force",


### PR DESCRIPTION
Should give a hint to completion generator that it should complete a path after `--config|-c`.
