### PR TITLE
Normalize all host variables to "h"

### DIFF
--- a/pkg/api/hosts.go
+++ b/pkg/api/hosts.go
@@ -29,7 +29,7 @@ func (hosts *Hosts) Last() *Host {
 }
 
 // Filter returns a filtered list of Hosts. The filter function should return true for hosts matching the criteria.
-func (hosts *Hosts) Filter(filter func(host *Host) bool) Hosts {
+func (hosts *Hosts) Filter(filter func(h *Host) bool) Hosts {
 	result := make(Hosts, 0, len(*hosts))
 
 	for _, h := range *hosts {
@@ -42,7 +42,7 @@ func (hosts *Hosts) Filter(filter func(host *Host) bool) Hosts {
 }
 
 // Find returns the first matching Host. The finder function should return true for a Host matching the criteria.
-func (hosts *Hosts) Find(filter func(host *Host) bool) *Host {
+func (hosts *Hosts) Find(filter func(h *Host) bool) *Host {
 	for _, h := range *hosts {
 		if filter(h) {
 			return (h)
@@ -52,7 +52,7 @@ func (hosts *Hosts) Find(filter func(host *Host) bool) *Host {
 }
 
 // Index returns the index of the first matching Host. The finder function should return true for a Host matching the criteria.
-func (hosts *Hosts) Index(filter func(host *Host) bool) int {
+func (hosts *Hosts) Index(filter func(h *Host) bool) int {
 	for i, h := range *hosts {
 		if filter(h) {
 			return (i)
@@ -62,7 +62,7 @@ func (hosts *Hosts) Index(filter func(host *Host) bool) int {
 }
 
 // IndexAll returns the indexes of the matching Hosts. The finder function should return true for a Host matching the criteria.
-func (hosts *Hosts) IndexAll(filter func(host *Host) bool) []int {
+func (hosts *Hosts) IndexAll(filter func(h *Host) bool) []int {
 	result := make([]int, 0, len(*hosts))
 	for i, h := range *hosts {
 		if filter(h) {
@@ -74,7 +74,7 @@ func (hosts *Hosts) IndexAll(filter func(host *Host) bool) []int {
 
 // Each runs a function on every Host. The function should return nil or an error. The first encountered error
 // will be returned and the process will be halted.
-func (hosts *Hosts) Each(filter func(host *Host) error) error {
+func (hosts *Hosts) Each(filter func(h *Host) error) error {
 	for _, h := range *hosts {
 		if err := filter(h); err != nil {
 			return fmt.Errorf("%s: %s", h.Address, err.Error())
@@ -85,7 +85,7 @@ func (hosts *Hosts) Each(filter func(host *Host) error) error {
 
 // ParallelEach runs a function on every Host parallelly. The function should return nil or an error.
 // Any errors will be concatenated and returned.
-func (hosts *Hosts) ParallelEach(filter func(host *Host) error) error {
+func (hosts *Hosts) ParallelEach(filter func(h *Host) error) error {
 	var wg sync.WaitGroup
 	var errors []string
 	type erritem struct {
@@ -121,7 +121,7 @@ func (hosts *Hosts) ParallelEach(filter func(host *Host) error) error {
 }
 
 // Map returns a new slice which is the result of running the map function on each host.
-func (hosts *Hosts) Map(filter func(host *Host) interface{}) []interface{} {
+func (hosts *Hosts) Map(filter func(h *Host) interface{}) []interface{} {
 	result := make([]interface{}, len(*hosts))
 	for i, h := range *hosts {
 		result[i] = filter(h)
@@ -130,7 +130,7 @@ func (hosts *Hosts) Map(filter func(host *Host) interface{}) []interface{} {
 }
 
 // MapString returns a new slice which is the result of running the map function on each host
-func (hosts *Hosts) MapString(filter func(host *Host) string) []string {
+func (hosts *Hosts) MapString(filter func(h *Host) string) []string {
 	result := make([]string, len(*hosts))
 	for i, h := range *hosts {
 		result[i] = filter(h)
@@ -139,7 +139,7 @@ func (hosts *Hosts) MapString(filter func(host *Host) string) []string {
 }
 
 // Include returns true if any of the hosts match the filter function criteria.
-func (hosts *Hosts) Include(filter func(host *Host) bool) bool {
+func (hosts *Hosts) Include(filter func(h *Host) bool) bool {
 	for _, h := range *hosts {
 		if filter(h) {
 			return true
@@ -149,6 +149,6 @@ func (hosts *Hosts) Include(filter func(host *Host) bool) bool {
 }
 
 // Count returns the count of hosts matching the filter function criteria.
-func (hosts *Hosts) Count(filter func(host *Host) bool) int {
+func (hosts *Hosts) Count(filter func(h *Host) bool) int {
 	return len(hosts.IndexAll(filter))
 }

--- a/pkg/dtr/dtr.go
+++ b/pkg/dtr/dtr.go
@@ -22,9 +22,9 @@ type Details struct {
 var ErrorNoSuchObject error = errors.New("No such object")
 
 // CollectDtrFacts gathers the current status of the installed DTR setup
-func CollectDtrFacts(dtrLeader *api.Host) (*api.DtrMetadata, error) {
+func CollectDtrFacts(h *api.Host) (*api.DtrMetadata, error) {
 	var details *Details
-	details, err := GetDTRDetails(dtrLeader)
+	details, err := GetDTRDetails(h)
 	if err != nil {
 		if errors.Is(err, ErrorNoSuchObject) {
 			return &api.DtrMetadata{Installed: false}, nil
@@ -42,8 +42,8 @@ func CollectDtrFacts(dtrLeader *api.Host) (*api.DtrMetadata, error) {
 
 // GetDTRDetails returns a struct containing the DTR version and replica ID from
 // the host it's executed on
-func GetDTRDetails(dtrHost *api.Host) (*Details, error) {
-	rethinkdbContainerID, err := dtrHost.ExecWithOutput(dtrHost.Configurer.DockerCommandf(`ps -aq --filter name=dtr-rethinkdb`))
+func GetDTRDetails(h *api.Host) (*Details, error) {
+	rethinkdbContainerID, err := h.ExecWithOutput(h.Configurer.DockerCommandf(`ps -aq --filter name=dtr-rethinkdb`))
 	if err != nil {
 		return nil, err
 	}
@@ -51,11 +51,11 @@ func GetDTRDetails(dtrHost *api.Host) (*Details, error) {
 		return nil, ErrorNoSuchObject
 	}
 
-	version, err := dtrHost.ExecWithOutput(dtrHost.Configurer.DockerCommandf(`inspect %s --format '{{ index .Config.Labels "com.docker.dtr.version"}}'`, rethinkdbContainerID))
+	version, err := h.ExecWithOutput(h.Configurer.DockerCommandf(`inspect %s --format '{{ index .Config.Labels "com.docker.dtr.version"}}'`, rethinkdbContainerID))
 	if err != nil {
 		return nil, err
 	}
-	replicaID, err := dtrHost.ExecWithOutput(dtrHost.Configurer.DockerCommandf(`inspect %s --format '{{ index .Config.Labels "com.docker.dtr.replica"}}'`, rethinkdbContainerID))
+	replicaID, err := h.ExecWithOutput(h.Configurer.DockerCommandf(`inspect %s --format '{{ index .Config.Labels "com.docker.dtr.replica"}}'`, rethinkdbContainerID))
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func GetDTRDetails(dtrHost *api.Host) (*Details, error) {
 		// If we failed to obtain either label then this DTR version does not
 		// support the version Config.Labels or something else may have gone
 		// wrong, attempt to pull these details with the old method
-		output, err := dtrHost.ExecWithOutput(dtrHost.Configurer.DockerCommandf(`inspect %s --format '{{ index .Config.Labels "com.docker.compose.project"}}'`, rethinkdbContainerID))
+		output, err := h.ExecWithOutput(h.Configurer.DockerCommandf(`inspect %s --format '{{ index .Config.Labels "com.docker.compose.project"}}'`, rethinkdbContainerID))
 		if err != nil {
 			return nil, err
 		}
@@ -131,8 +131,8 @@ func SequentialReplicaID(replicaInt int) string {
 
 // GetBootstrapVersion gets the version of bootstrapper image from the specified
 // host
-func GetBootstrapVersion(dtrHost *api.Host, config *api.ClusterConfig) (string, error) {
-	output, err := dtrHost.ExecWithOutput(dtrHost.Configurer.DockerCommandf(`image inspect %s --format '{{.RepoTags}}'`, config.Spec.Dtr.GetBootstrapperImage()))
+func GetBootstrapVersion(h *api.Host, config *api.ClusterConfig) (string, error) {
+	output, err := h.ExecWithOutput(h.Configurer.DockerCommandf(`image inspect %s --format '{{.RepoTags}}'`, config.Spec.Dtr.GetBootstrapperImage()))
 	if err != nil {
 		return "", err
 	}
@@ -179,10 +179,10 @@ func ucpURLHost(config *api.ClusterConfig) string {
 // Destroy is functionally equivalent to a DTR destroy and is intended to
 // remove any DTR containers and volumes that may have been started via the
 // installer if it fails
-func Destroy(dtrHost *api.Host) error {
+func Destroy(h *api.Host) error {
 	// Remove containers
-	log.Debugf("%s: Removing DTR containers", dtrHost.Address)
-	containersToRemove, err := dtrHost.ExecWithOutput(dtrHost.Configurer.DockerCommandf("ps -aq --filter name=dtr-"))
+	log.Debugf("%s: Removing DTR containers", h.Address)
+	containersToRemove, err := h.ExecWithOutput(h.Configurer.DockerCommandf("ps -aq --filter name=dtr-"))
 	if err != nil {
 		return err
 	}
@@ -190,14 +190,14 @@ func Destroy(dtrHost *api.Host) error {
 		log.Debugf("No DTR containers to remove")
 	} else {
 		containersToRemove = strings.Join(strings.Fields(containersToRemove), " ")
-		if err := dtrHost.Exec(dtrHost.Configurer.DockerCommandf("rm -f %s", containersToRemove)); err != nil {
+		if err := h.Exec(h.Configurer.DockerCommandf("rm -f %s", containersToRemove)); err != nil {
 			return err
 		}
 	}
 
 	// Remove volumes
-	log.Debugf("%s: Removing DTR volumes", dtrHost.Address)
-	volumeOutput, err := dtrHost.ExecWithOutput(dtrHost.Configurer.DockerCommandf("volume ls -q"))
+	log.Debugf("%s: Removing DTR volumes", h.Address)
+	volumeOutput, err := h.ExecWithOutput(h.Configurer.DockerCommandf("volume ls -q"))
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func Destroy(dtrHost *api.Host) error {
 			return nil
 		}
 		volumes := strings.Join(volumesToRemove, " ")
-		err = dtrHost.Exec(dtrHost.Configurer.DockerCommandf("volume rm -f %s", volumes))
+		err = h.Exec(h.Configurer.DockerCommandf("volume rm -f %s", volumes))
 		if err != nil {
 			return err
 		}

--- a/pkg/phase/clean_up.go
+++ b/pkg/phase/clean_up.go
@@ -25,9 +25,9 @@ func (p *CleanUp) Run() error {
 	return nil
 }
 
-func (p *CleanUp) cleanupEnv(host *api.Host, c *api.ClusterConfig) error {
-	if len(host.Environment) > 0 {
-		return host.Configurer.CleanupEnvironment()
+func (p *CleanUp) cleanupEnv(h *api.Host, c *api.ClusterConfig) error {
+	if len(h.Environment) > 0 {
+		return h.Configurer.CleanupEnvironment()
 	}
 	return nil
 }

--- a/pkg/phase/connect.go
+++ b/pkg/phase/connect.go
@@ -22,33 +22,33 @@ func (p *Connect) Run() error {
 	return runParallelOnHosts(p.config.Spec.Hosts, p.config, p.connectHost)
 }
 
-func (p *Connect) connectHost(host *api.Host, c *api.ClusterConfig) error {
+func (p *Connect) connectHost(h *api.Host, c *api.ClusterConfig) error {
 	proto := "SSH"
 
-	if host.Localhost {
+	if h.Localhost {
 		proto = "Local"
-	} else if host.WinRM != nil {
+	} else if h.WinRM != nil {
 		proto = "WinRM"
 	}
 
 	err := retry.Do(
 		func() error {
-			log.Infof("%s: opening %s connection", host.Address, proto)
-			err := host.Connect()
+			log.Infof("%s: opening %s connection", h.Address, proto)
+			err := h.Connect()
 			if err != nil {
-				log.Errorf("%s: failed to connect -> %s", host.Address, err.Error())
+				log.Errorf("%s: failed to connect -> %s", h.Address, err.Error())
 			}
 			return err
 		},
 		retry.Attempts(6),
 	)
 	if err != nil {
-		log.Errorf("%s: failed to open connection", host.Address)
+		log.Errorf("%s: failed to open connection", h.Address)
 		return err
 	}
 
-	log.Printf("%s: %s connection opened", host.Address, proto)
-	return p.testConnection(host)
+	log.Printf("%s: %s connection opened", h.Address, proto)
+	return p.testConnection(h)
 }
 
 func (p *Connect) testConnection(h *api.Host) error {

--- a/pkg/phase/disconnect.go
+++ b/pkg/phase/disconnect.go
@@ -21,8 +21,8 @@ func (p *Disconnect) Run() error {
 	return runParallelOnHosts(p.config.Spec.Hosts, p.config, p.disconnectHost)
 }
 
-func (p *Disconnect) disconnectHost(host *api.Host, c *api.ClusterConfig) error {
-	host.Disconnect()
-	log.Printf("%s: connection closed", host.Address)
+func (p *Disconnect) disconnectHost(h *api.Host, c *api.ClusterConfig) error {
+	h.Disconnect()
+	log.Printf("%s: connection closed", h.Address)
 	return nil
 }

--- a/pkg/phase/install_engine.go
+++ b/pkg/phase/install_engine.go
@@ -77,9 +77,9 @@ func (p *InstallEngine) upgradeEngines(c *api.ClusterConfig) error {
 	wp := workerpool.New(concurrentUpgrades)
 	mu := sync.Mutex{}
 	installErrors := &Error{}
-	for _, host := range workers {
-		if host.Metadata.EngineVersion != "" {
-			h := host
+	for _, w := range workers {
+		if w.Metadata.EngineVersion != "" {
+			h := w
 			wp.Submit(func() {
 				err := p.installEngine(h, c)
 				if err != nil {
@@ -97,42 +97,42 @@ func (p *InstallEngine) upgradeEngines(c *api.ClusterConfig) error {
 	return nil
 }
 
-func (p *InstallEngine) installEngine(host *api.Host, c *api.ClusterConfig) error {
-	newInstall := host.Metadata.EngineVersion == ""
-	prevVersion := host.Metadata.EngineVersion
+func (p *InstallEngine) installEngine(h *api.Host, c *api.ClusterConfig) error {
+	newInstall := h.Metadata.EngineVersion == ""
+	prevVersion := h.Metadata.EngineVersion
 
 	err := retry.Do(
 		func() error {
 			if newInstall {
-				log.Infof("%s: installing engine (%s)", host.Address, c.Spec.Engine.Version)
+				log.Infof("%s: installing engine (%s)", h.Address, c.Spec.Engine.Version)
 			} else {
-				log.Infof("%s: updating engine (%s -> %s)", host.Address, prevVersion, c.Spec.Engine.Version)
+				log.Infof("%s: updating engine (%s -> %s)", h.Address, prevVersion, c.Spec.Engine.Version)
 			}
-			return host.Configurer.InstallEngine(&c.Spec.Engine)
+			return h.Configurer.InstallEngine(&c.Spec.Engine)
 		},
 	)
 	if err != nil {
 		if newInstall {
-			log.Errorf("%s: failed to install engine -> %s", host.Address, err.Error())
+			log.Errorf("%s: failed to install engine -> %s", h.Address, err.Error())
 		} else {
-			log.Errorf("%s: failed to update engine -> %s", host.Address, err.Error())
+			log.Errorf("%s: failed to update engine -> %s", h.Address, err.Error())
 		}
 
 		return err
 	}
 
-	currentVersion, err := host.EngineVersion()
+	currentVersion, err := h.EngineVersion()
 	if err != nil {
-		return fmt.Errorf("%s: failed to query engine version after installation: %s", host.Address, err.Error())
+		return fmt.Errorf("%s: failed to query engine version after installation: %s", h.Address, err.Error())
 	}
 
 	if !newInstall && currentVersion == prevVersion {
-		err = host.Configurer.RestartEngine()
+		err = h.Configurer.RestartEngine()
 		if err != nil {
-			return fmt.Errorf("%s: failed to restart engine", host.Address)
+			return fmt.Errorf("%s: failed to restart engine", h.Address)
 		}
 	}
 
-	log.Infof("%s: engine version %s installed", host.Address, c.Spec.Engine.Version)
+	log.Infof("%s: engine version %s installed", h.Address, c.Spec.Engine.Version)
 	return nil
 }

--- a/pkg/phase/install_ucp.go
+++ b/pkg/phase/install_ucp.go
@@ -178,8 +178,8 @@ func applyCloudConfig(config *api.ClusterConfig) error {
 	return err
 }
 
-func cleanupUcp(host *api.Host) error {
-	containersToRemove, err := host.ExecWithOutput(host.Configurer.DockerCommandf("ps -aq --filter name=ucp-"))
+func cleanupUcp(h *api.Host) error {
+	containersToRemove, err := h.ExecWithOutput(h.Configurer.DockerCommandf("ps -aq --filter name=ucp-"))
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func cleanupUcp(host *api.Host) error {
 		return nil
 	}
 	containersToRemove = strings.ReplaceAll(containersToRemove, "\n", " ")
-	if err := host.Exec(host.Configurer.DockerCommandf("rm -f %s", containersToRemove)); err != nil {
+	if err := h.Exec(h.Configurer.DockerCommandf("rm -f %s", containersToRemove)); err != nil {
 		return err
 	}
 

--- a/pkg/phase/phase.go
+++ b/pkg/phase/phase.go
@@ -121,9 +121,9 @@ func NewError(err string) *Error {
 	}
 }
 
-func runParallelOnHosts(hosts api.Hosts, config *api.ClusterConfig, action func(host *api.Host, config *api.ClusterConfig) error) error {
-	return hosts.ParallelEach(func(host *api.Host) error {
-		err := action(host, config)
+func runParallelOnHosts(hosts api.Hosts, config *api.ClusterConfig, action func(h *api.Host, config *api.ClusterConfig) error) error {
+	return hosts.ParallelEach(func(h *api.Host) error {
+		err := action(h, config)
 		if err != nil {
 			log.Error(err.Error())
 		}

--- a/pkg/phase/prepare_host.go
+++ b/pkg/phase/prepare_host.go
@@ -32,30 +32,30 @@ func (p *PrepareHost) Run() error {
 	return nil
 }
 
-func (p *PrepareHost) installBasePackages(host *api.Host, c *api.ClusterConfig) error {
+func (p *PrepareHost) installBasePackages(h *api.Host, c *api.ClusterConfig) error {
 	err := retry.Do(
 		func() error {
-			log.Infof("%s: installing base packages", host.Address)
-			err := host.Configurer.InstallBasePackages()
+			log.Infof("%s: installing base packages", h.Address)
+			err := h.Configurer.InstallBasePackages()
 
 			return err
 		},
 	)
 	if err != nil {
-		log.Errorf("%s: failed to install base packages -> %s", host.Address, err.Error())
+		log.Errorf("%s: failed to install base packages -> %s", h.Address, err.Error())
 		return err
 	}
 
-	log.Printf("%s: base packages installed", host.Address)
+	log.Printf("%s: base packages installed", h.Address)
 	return nil
 }
 
-func (p *PrepareHost) updateEnvironment(host *api.Host, c *api.ClusterConfig) error {
-	if len(host.Environment) > 0 {
-		log.Infof("%s: updating environment", host.Address)
-		return host.Configurer.UpdateEnvironment()
+func (p *PrepareHost) updateEnvironment(h *api.Host, c *api.ClusterConfig) error {
+	if len(h.Environment) > 0 {
+		log.Infof("%s: updating environment", h.Address)
+		return h.Configurer.UpdateEnvironment()
 	}
 
-	log.Debugf("%s: no environment variables specified for the host", host.Address)
+	log.Debugf("%s: no environment variables specified for the host", h.Address)
 	return nil
 }

--- a/pkg/phase/remove_nodes.go
+++ b/pkg/phase/remove_nodes.go
@@ -129,8 +129,8 @@ func (p *RemoveNodes) currentNodeIDs(config *api.ClusterConfig) ([]string, error
 	return nodeIDs, nil
 }
 
-func (p *RemoveNodes) swarmNodeIDs(swarmLeader *api.Host) ([]string, error) {
-	output, err := swarmLeader.ExecWithOutput(swarmLeader.Configurer.DockerCommandf(`node ls --format="{{.ID}}"`))
+func (p *RemoveNodes) swarmNodeIDs(h *api.Host) ([]string, error) {
+	output, err := h.ExecWithOutput(h.Configurer.DockerCommandf(`node ls --format="{{.ID}}"`))
 	if err != nil {
 		log.Errorln(output)
 		return []string{}, err
@@ -138,40 +138,40 @@ func (p *RemoveNodes) swarmNodeIDs(swarmLeader *api.Host) ([]string, error) {
 	return strings.Split(output, "\n"), nil
 }
 
-func (p *RemoveNodes) removeNode(swarmLeader *api.Host, nodeID string) error {
-	nodeAddr, err := swarmLeader.ExecWithOutput(swarmLeader.Configurer.DockerCommandf(`node inspect %s --format {{.Status.Addr}}`, nodeID))
+func (p *RemoveNodes) removeNode(h *api.Host, nodeID string) error {
+	nodeAddr, err := h.ExecWithOutput(h.Configurer.DockerCommandf(`node inspect %s --format {{.Status.Addr}}`, nodeID))
 	if err != nil {
 		return err
 	}
-	log.Infof("%s: removing orphan node %s", swarmLeader.Address, nodeAddr)
-	nodeRole, err := swarmLeader.ExecWithOutput(swarmLeader.Configurer.DockerCommandf(`node inspect %s --format {{.Spec.Role}}`, nodeID))
+	log.Infof("%s: removing orphan node %s", h.Address, nodeAddr)
+	nodeRole, err := h.ExecWithOutput(h.Configurer.DockerCommandf(`node inspect %s --format {{.Spec.Role}}`, nodeID))
 	if err != nil {
 		return err
 	}
 	if nodeRole == "manager" {
-		log.Infof("%s: demoting orphan node %s", swarmLeader.Address, nodeAddr)
-		err = swarmLeader.Exec(swarmLeader.Configurer.DockerCommandf(`node demote %s`, nodeID))
+		log.Infof("%s: demoting orphan node %s", h.Address, nodeAddr)
+		err = h.Exec(h.Configurer.DockerCommandf(`node demote %s`, nodeID))
 		if err != nil {
 			return err
 		}
-		log.Infof("%s: orphan node %s demoted", swarmLeader.Address, nodeAddr)
+		log.Infof("%s: orphan node %s demoted", h.Address, nodeAddr)
 	}
 
-	log.Infof("%s: draining orphan node %s", swarmLeader.Address, nodeAddr)
-	drainCmd := swarmLeader.Configurer.DockerCommandf("node update --availability drain %s", nodeID)
-	err = swarmLeader.Exec(drainCmd)
+	log.Infof("%s: draining orphan node %s", h.Address, nodeAddr)
+	drainCmd := h.Configurer.DockerCommandf("node update --availability drain %s", nodeID)
+	err = h.Exec(drainCmd)
 	if err != nil {
 		return err
 	}
 	time.Sleep(30 * time.Second)
-	log.Infof("%s: orphan node %s drained", swarmLeader.Address, nodeAddr)
+	log.Infof("%s: orphan node %s drained", h.Address, nodeAddr)
 
-	removeCmd := swarmLeader.Configurer.DockerCommandf("node rm --force %s", nodeID)
-	err = swarmLeader.Exec(removeCmd)
+	removeCmd := h.Configurer.DockerCommandf("node rm --force %s", nodeID)
+	err = h.Exec(removeCmd)
 	if err != nil {
 		return err
 	}
-	log.Infof("%s: removed orphan node %s", swarmLeader.Address, nodeAddr)
+	log.Infof("%s: removed orphan node %s", h.Address, nodeAddr)
 	return nil
 }
 
@@ -204,8 +204,8 @@ func (p *RemoveNodes) removeDtrNode(config *api.ClusterConfig, replicaID string)
 
 // isManagedByUs returns a struct of isManaged which contains two bools, one
 // which declares node wide management and one which declares dtr management
-func (p *RemoveNodes) isManagedByUs(swarmLeader *api.Host, nodeID string) isManaged {
-	labels, err := swarmLeader.ExecWithOutput(swarmLeader.Configurer.DockerCommandf(`node inspect %s --format="{{json .Spec.Labels}}"`, nodeID))
+func (p *RemoveNodes) isManagedByUs(h *api.Host, nodeID string) isManaged {
+	labels, err := h.ExecWithOutput(h.Configurer.DockerCommandf(`node inspect %s --format="{{json .Spec.Labels}}"`, nodeID))
 	var managed isManaged
 	if err != nil {
 		return managed
@@ -217,9 +217,9 @@ func (p *RemoveNodes) isManagedByUs(swarmLeader *api.Host, nodeID string) isMana
 
 // getReplicaIDFromHostname retreives the replicaID from the container name
 // associated with hostname
-func (p *RemoveNodes) getReplicaIDFromHostname(config *api.ClusterConfig, swarmLeader *api.Host, hostname string) (string, error) {
+func (p *RemoveNodes) getReplicaIDFromHostname(config *api.ClusterConfig, h *api.Host, hostname string) (string, error) {
 	// Setup httpClient
-	tlsConfig, err := ucp.GetTLSConfigFrom(swarmLeader, config.Spec.Ucp.ImageRepo, config.Spec.Ucp.Version)
+	tlsConfig, err := ucp.GetTLSConfigFrom(h, config.Spec.Ucp.ImageRepo, config.Spec.Ucp.Version)
 	if err != nil {
 		return "", fmt.Errorf("error getting TLS config: %w", err)
 	}

--- a/pkg/phase/run_hooks.go
+++ b/pkg/phase/run_hooks.go
@@ -17,8 +17,8 @@ type RunHooks struct {
 }
 
 // HostFilterFunc returns true for hosts that have non-empty list of hooks returned by the StepListFunc
-func (p *RunHooks) HostFilterFunc(host *api.Host) bool {
-	steps := p.StepListFunc(host)
+func (p *RunHooks) HostFilterFunc(h *api.Host) bool {
+	steps := p.StepListFunc(h)
 	return len(*steps) > 0
 }
 

--- a/pkg/phase/uninstall_engine.go
+++ b/pkg/phase/uninstall_engine.go
@@ -21,16 +21,16 @@ func (p *UninstallEngine) Run() error {
 	return runParallelOnHosts(p.config.Spec.Hosts, p.config, p.uninstallEngine)
 }
 
-func (p *UninstallEngine) uninstallEngine(host *api.Host, c *api.ClusterConfig) error {
-	err := host.Exec(host.Configurer.DockerCommandf("info"))
+func (p *UninstallEngine) uninstallEngine(h *api.Host, c *api.ClusterConfig) error {
+	err := h.Exec(h.Configurer.DockerCommandf("info"))
 	if err != nil {
-		log.Infof("%s: engine not installed, skipping", host.Address)
+		log.Infof("%s: engine not installed, skipping", h.Address)
 		return nil
 	}
-	log.Infof("%s: uninstalling engine", host.Address)
-	err = host.Configurer.UninstallEngine(&c.Spec.Engine)
+	log.Infof("%s: uninstalling engine", h.Address)
+	err = h.Configurer.UninstallEngine(&c.Spec.Engine)
 	if err == nil {
-		log.Infof("%s: engine uninstalled", host.Address)
+		log.Infof("%s: engine uninstalled", h.Address)
 	}
 
 	return err

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -6,10 +6,10 @@ import (
 )
 
 // IsSwarmNode check whether the given node is already part of swarm
-func IsSwarmNode(host *api.Host) bool {
-	output, err := NodeID(host)
+func IsSwarmNode(h *api.Host) bool {
+	output, err := NodeID(h)
 	if err != nil {
-		log.Warnf("failed to get hosts swarm status")
+		log.Warnf("%s: failed to get host's swarm status", h.Address)
 		return false
 	}
 
@@ -21,15 +21,15 @@ func IsSwarmNode(host *api.Host) bool {
 }
 
 // NodeID returns the hosts node id in swarm cluster
-func NodeID(host *api.Host) (string, error) {
-	return host.ExecWithOutput(host.Configurer.DockerCommandf(`info --format "{{.Swarm.NodeID}}"`))
+func NodeID(h *api.Host) (string, error) {
+	return h.ExecWithOutput(h.Configurer.DockerCommandf(`info --format "{{.Swarm.NodeID}}"`))
 }
 
 // ClusterID digs the swarm cluster id from swarm leader host
-func ClusterID(leader *api.Host) string {
-	output, err := leader.ExecWithOutput(leader.Configurer.DockerCommandf(`info --format "{{ .Swarm.Cluster.ID}}"`))
+func ClusterID(h *api.Host) string {
+	output, err := h.ExecWithOutput(h.Configurer.DockerCommandf(`info --format "{{ .Swarm.Cluster.ID}}"`))
 	if err != nil {
-		log.Warnf("failed to get host's swarm status, probably not part of swarm")
+		log.Warnf("%s: failed to get host's swarm status, probably not part of swarm", h.Address)
 		return ""
 	}
 


### PR DESCRIPTION
There are several `func xx(host *Host)`,  `func xx(dtrHost *api.Host)`, etc. This PR normalizes all of such to just use `h` like the rest of the codebase.
