### PR TITLE
Remove apply --prune and move setting to spec.cluster.prune

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -22,11 +22,6 @@ func NewApplyCommand() *cli.Command {
 				Value:   "launchpad.yaml",
 			},
 			&cli.BoolFlag{
-				Name:  "prune",
-				Usage: "Automatically remove nodes that are no longer a part of cluster config yaml",
-				Value: false,
-			},
-			&cli.BoolFlag{
 				Name:    "force",
 				Aliases: []string{"f"},
 				Usage:   "Allow continuing in some situations where prerequisite checks fail",
@@ -51,7 +46,6 @@ func NewApplyCommand() *cli.Command {
 
 			err := apply.Apply(&apply.Options{
 				Config:      ctx.String("config"),
-				Prune:       ctx.Bool("prune"),
 				Force:       ctx.Bool("force"),
 				Debug:       ctx.Bool("debug") || ctx.Bool("trace"),
 				SkipCleanup: ctx.Bool("disable-cleanup"),

--- a/pkg/api/cluster_spec.go
+++ b/pkg/api/cluster_spec.go
@@ -16,12 +16,18 @@ type ClusterSpecMetadata struct {
 	Force bool
 }
 
+// Cluster is for universal cluster settings not applicable to single hosts, ucp, dtr or engine
+type Cluster struct {
+	Prune bool `yaml:"prune" default:"false"`
+}
+
 // ClusterSpec defines cluster spec
 type ClusterSpec struct {
-	Hosts  Hosts        `yaml:"hosts" validate:"required,dive,min=1"`
-	Ucp    UcpConfig    `yaml:"ucp,omitempty"`
-	Dtr    *DtrConfig   `yaml:"dtr,omitempty"`
-	Engine EngineConfig `yaml:"engine,omitempty"`
+	Hosts   Hosts        `yaml:"hosts" validate:"required,dive,min=1"`
+	Ucp     UcpConfig    `yaml:"ucp,omitempty"`
+	Dtr     *DtrConfig   `yaml:"dtr,omitempty"`
+	Engine  EngineConfig `yaml:"engine,omitempty"`
+	Cluster Cluster      `yaml:"cluster"`
 
 	Metadata ClusterSpecMetadata `yaml:"-"`
 }

--- a/pkg/cmd/apply/apply.go
+++ b/pkg/cmd/apply/apply.go
@@ -23,7 +23,6 @@ import (
 // Options for apply
 type Options struct {
 	Config      string
-	Prune       bool
 	Force       bool
 	SkipCleanup bool
 	Debug       bool
@@ -98,9 +97,7 @@ func Apply(opts *Options) error {
 		phaseManager.AddPhase(&phase.JoinDtrReplicas{})
 	}
 	phaseManager.AddPhase(&phase.LabelNodes{})
-	if opts.Prune {
-		phaseManager.AddPhase(&phase.RemoveNodes{})
-	}
+	phaseManager.AddPhase(&phase.RemoveNodes{})
 	phaseManager.AddPhase(&phase.RunHooks{Stage: "After", Action: "Apply", StepListFunc: func(h *api.Host) *[]string { return h.Hooks.Apply.After }})
 	phaseManager.AddPhase(&phase.Disconnect{})
 	phaseManager.AddPhase(&phase.Info{})

--- a/test/launchpad-dtr.yaml.tpl
+++ b/test/launchpad-dtr.yaml.tpl
@@ -22,12 +22,14 @@ spec:
         keyPath: "./id_rsa_launchpad"
         user: "root"
       role: "dtr"
-    - address: "127.0.0.1"
-      ssh:
-        port: 9025
-        keyPath: "./id_rsa_launchpad"
-        user: "root"
-      role: "dtr"
+    - address: "127.0.0.1" # REMOVE_THIS
+      ssh: # REMOVE_THIS
+        port: 9025 # REMOVE_THIS
+        keyPath: "./id_rsa_launchpad" # REMOVE_THIS
+        user: "root" # REMOVE_THIS
+      role: "dtr" # REMOVE_THIS
+  cluster:
+    prune: false
   ucp:
     version: $UCP_VERSION
     imageRepo: $UCP_IMAGE_REPO

--- a/test/smoke_prune.sh
+++ b/test/smoke_prune.sh
@@ -8,13 +8,31 @@ trap cleanup EXIT
 
 [ "${REUSE_CLUSTER}" = "" ] && setup && ../bin/launchpad --debug apply
 
-# Remove a node from the launchpad.yaml and run apply with --prune
+UNAME=$(uname)
+if [ "${UNAME}" = "Darwin" ]; then
+  SEDOPTS="-i -e"
+else
+  SEDOPTS="-i"
+fi
+
+# Remove a node from the launchpad.yaml
 echo -e "Removing one DTR node from launchpad.yaml..."
-sed -i '25,30d' launchpad.yaml
+sed $SEDOPTS '/REMOVE_THIS/d' launchpad.yaml
 cat launchpad.yaml
 
 ../bin/launchpad describe hosts
-../bin/launchpad --debug apply --prune
+
+echo "Running with prune: false"
+../bin/launchpad --debug apply
+
+# Flip prune to true
+echo -e "Changing prune: false to prune: true..."
+sed $SEDOPTS 's/prune: false/prune: true/' launchpad.yaml
+cat launchpad.yaml
+
+echo "Running with prune: true"
+../bin/launchpad --debug apply
+
 ../bin/launchpad describe hosts
 ../bin/launchpad describe ucp
 ../bin/launchpad describe dtr


### PR DESCRIPTION
`apply --prune` is too UCP specific.

Example YAML:

```yaml
spec:
  cluster:
    prune: true
```

Even if prune is false, the list of prunable objects is built and a warning will be displayed when there is something to prune but prune is false.
