### PR TITLE
Fix panic when running without UCP config

### DIFF
--- a/pkg/api/ucp_config.go
+++ b/pkg/api/ucp_config.go
@@ -116,6 +116,7 @@ func NewUcpConfig() UcpConfig {
 	return UcpConfig{
 		Version:   constant.UCPVersion,
 		ImageRepo: constant.ImageRepo,
+		Metadata:  &UcpMetadata{},
 	}
 }
 

--- a/pkg/phase/validate_facts.go
+++ b/pkg/phase/validate_facts.go
@@ -65,10 +65,6 @@ func (p *ValidateFacts) populateSan() {
 
 // validateDTRVersionJump validates UCP upgrade path
 func (p *ValidateFacts) validateUCPVersionJump(conf *api.ClusterConfig) error {
-	if conf.Spec.Ucp.Metadata == nil {
-		return nil
-	}
-
 	if conf.Spec.Ucp.Metadata.Installed && conf.Spec.Ucp.Metadata.InstalledVersion != "" {
 		installedUCP, err := version.NewVersion(conf.Spec.Ucp.Metadata.InstalledVersion)
 		if err != nil {


### PR DESCRIPTION
If you run `launchpad apply` with a config that does not have a `ucp` section, launchpad crashes.

```
INFO[0000] ==> Running phase: Validate Facts
WARN[0000] manager0: added manager node's public address to ucp installFlag SANs: --san=127.0.0.1
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x149f062]

goroutine 1 [running]:
github.com/Mirantis/mcc/pkg/phase.(*ValidateFacts).validateUCPVersionJump(0xc0003c3ea0, 0xc0003b7020, 0x0, 0x163107a)
	/Users/kimmo/Projects/go/src/github.com/Mirantis/mcc/pkg/phase/validate_facts.go:68 +0x42
```

This is because normally when you have a `ucp` section, the `UnmarshalYAML` adds a blank metadata. When there is no `ucp`, the clusterspec uses `NewUCPConfig` which did not add a blank `UcpMetadata`.

