### PR TITLE
Add message about running installer

### DIFF
--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -58,6 +58,9 @@ func (c *LinuxConfigurer) InstallEngine(engineConfig *api.EngineConfig) error {
 	defer c.DeleteFile(installer)
 
 	cmd := fmt.Sprintf("DOCKER_URL=%s CHANNEL=%s VERSION=%s bash %s", engineConfig.RepoURL, engineConfig.Channel, engineConfig.Version, escape.Quote(installer))
+
+	log.Infof("%s: running installer", c.Host)
+
 	if err := c.Host.Exec(cmd); err != nil {
 		return err
 	}

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -73,13 +73,15 @@ func (c *WindowsConfigurer) InstallEngine(engineConfig *api.EngineConfig) error 
 
 	installCommand := fmt.Sprintf("set DOWNLOAD_URL=%s && set DOCKER_VERSION=%s && set CHANNEL=%s && powershell -ExecutionPolicy Bypass -NoProfile -NonInteractive -File %s -Verbose", engineConfig.RepoURL, engineConfig.Version, engineConfig.Channel, ps.DoubleQuote(installer))
 
+	log.Infof("%s: running installer", c.Host)
+
 	output, err := c.Host.ExecWithOutput(installCommand)
 	if err != nil {
 		return err
 	}
 
 	if strings.Contains(output, "Your machine needs to be rebooted") {
-		log.Warnf("%s: host needs to be rebooted", c.Host.Address)
+		log.Warnf("%s: host needs to be rebooted", c.Host)
 		return c.Host.Reboot()
 	}
 


### PR DESCRIPTION
From the output it seems like nothing is happening after uploading the engine installer.

Before:

```console
INFO[0022] ==> Running phase: Install Docker EE Engine on the hosts
INFO[0022] worker0: installing engine (19.03.12)
INFO[0022] manager0: installing engine (19.03.12)
INFO[0022] manager0: uploading 9 KiB to /root/installerLinux532985089
INFO[0022] worker0: uploading 9 KiB to /root/installerLinux532985089
INFO[0022] worker0: transfered 9 KiB in 0.0 seconds (846 KiB/s)
INFO[0022] manager0: transfered 9 KiB in 0.0 seconds (691 KiB/s)
# waiting for a minute or two
INFO[0159] manager0: engine version 19.03.12 installed
INFO[0159] worker0: engine version 19.03.12 installed
```

After:

```console
INFO[0022] ==> Running phase: Install Docker EE Engine on the hosts
INFO[0022] worker0: installing engine (19.03.12)
INFO[0022] manager0: installing engine (19.03.12)
INFO[0022] manager0: uploading 9 KiB to /root/installerLinux532985089
INFO[0022] worker0: uploading 9 KiB to /root/installerLinux532985089
INFO[0022] worker0: transfered 9 KiB in 0.0 seconds (846 KiB/s)
INFO[0022] manager0: transfered 9 KiB in 0.0 seconds (691 KiB/s)
INFO[0022] worker0: running installer
INFO[0022] manager0: running installer
# waiting for a minute or two
INFO[0159] manager0: engine version 19.03.12 installed
INFO[0159] worker0: engine version 19.03.12 installed
```
