### PR TITLE
Detect UCP installer generated admin password and use in DTR install

### DIFF
--- a/pkg/phase/install_ucp.go
+++ b/pkg/phase/install_ucp.go
@@ -2,6 +2,7 @@ package phase
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Mirantis/mcc/pkg/api"
@@ -105,9 +106,18 @@ func (p *InstallUCP) Run() (err error) {
 	}
 
 	installCmd := swarmLeader.Configurer.DockerCommandf("run %s %s install %s", strings.Join(runFlags, " "), image, strings.Join(installFlags, " "))
-	err = swarmLeader.Exec(installCmd, exec.StreamOutput(), exec.Redact(`--admin\S+`))
+	output, err := swarmLeader.ExecWithOutput(installCmd, exec.StreamOutput(), exec.Redact(`--admin\S+`))
 	if err != nil {
 		return fmt.Errorf("%s: failed to run UCP installer: %s", swarmLeader, err.Error())
+	}
+
+	if installFlags.GetValue("--admin-password") == "" {
+		re := regexp.MustCompile(`msg="Generated random admin password: (.+?)"`)
+		md := re.FindStringSubmatch(output)
+		if len(md) > 0 && md[1] != "" {
+			log.Debugf("%s: adding the auto-generated admin password to installflags", swarmLeader)
+			p.config.Spec.Ucp.InstallFlags.AddOrReplace(`--admin-password="` + md[1] + `"`)
+		}
 	}
 
 	err = ucp.CollectFacts(swarmLeader, p.config.Spec.Ucp.Metadata)


### PR DESCRIPTION
If you don't add `--admin-password` or `--ucp-password`, you can't install DTR.

UCP generates an admin password but launchpad does not utilize it.

This PR makes launchpad grab that password and add it as `--admin-password` install flag. This will make DTR installation use that password when `--ucp-password` has not been set.

