### PR TITLE
Don't display the [0000] style terminal log timestamps

### DIFF
--- a/pkg/log/formatter_hook.go
+++ b/pkg/log/formatter_hook.go
@@ -40,7 +40,7 @@ func (hook *FormatterWriterHook) Levels() []log.Level {
 func NewStdoutHook(debugEnabled bool) *FormatterWriterHook {
 	stdoutHook := &FormatterWriterHook{
 		Writer:    os.Stdout,
-		Formatter: &log.TextFormatter{ForceColors: true},
+		Formatter: &log.TextFormatter{ForceColors: true, DisableTimestamp: true},
 		LogLevels: []log.Level{
 			log.InfoLevel,
 			log.PanicLevel,


### PR DESCRIPTION
I think they're seconds.

Before:
```
INFO[0000] ==> Running phase: Open Remote Connection
INFO[0000] 127.0.0.1: opening SSH connection
INFO[0000] 127.0.0.1: opening SSH connection
```

After:
```
INFO ==> Running phase: Open Remote Connection
INFO 127.0.0.1: opening SSH connection
INFO 127.0.0.1: opening SSH connection
```