### PR TITLE
Increase the initial connect retry time

### DIFF
--- a/pkg/product/common/phase/connect.go
+++ b/pkg/product/common/phase/connect.go
@@ -1,6 +1,8 @@
 package phase
 
 import (
+	"time"
+
 	"github.com/Mirantis/mcc/pkg/api"
 	"github.com/Mirantis/mcc/pkg/phase"
 	retry "github.com/avast/retry-go"
@@ -28,7 +30,10 @@ func (p *Connect) connectHost(h *api.Host, c *api.ClusterConfig) error {
 		func() error {
 			return h.Connect()
 		},
-		retry.Attempts(6),
+		retry.DelayType(retry.RandomDelay),
+		retry.MaxJitter(time.Second*2),
+		retry.Delay(time.Second*10),
+		retry.Attempts(30),
 	)
 
 	if err != nil {


### PR DESCRIPTION
As noted by @quadespresso on slack, launchpad gives up a bit too easily when trying to connect to the hosts.

This PR changes the retry to use 9-11 second random intervals for a total of about 5 minutes instead of the "retry 6 times with back-off delay".
