### PR TITLE
Add --disable-redact and --confirm

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mirantis/mcc/pkg/analytics"
 	"github.com/Mirantis/mcc/pkg/config"
 	"github.com/Mirantis/mcc/pkg/constant"
+	"github.com/Mirantis/mcc/pkg/exec"
 	mcclog "github.com/Mirantis/mcc/pkg/log"
 	"github.com/Mirantis/mcc/pkg/util"
 	"github.com/Mirantis/mcc/version"
@@ -45,8 +46,20 @@ func NewApplyCommand() *cli.Command {
 				Value:  false,
 				Hidden: true,
 			},
+			&cli.BoolFlag{
+				Name:  "confirm",
+				Usage: "Ask confirmation for all commands",
+				Value: false,
+			},
+			&cli.BoolFlag{
+				Name:  "disable-redact",
+				Usage: "Do not hide sensitive information in the output",
+				Value: false,
+			},
 		},
 		Before: func(ctx *cli.Context) error {
+			exec.Confirm = ctx.Bool("confirm")
+			exec.DisableRedact = ctx.Bool("disable-redact")
 			if !ctx.Bool("accept-license") {
 				return analytics.RequireRegisteredUser()
 			}

--- a/cmd/client_config.go
+++ b/cmd/client_config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Mirantis/mcc/pkg/analytics"
 	"github.com/Mirantis/mcc/pkg/config"
+	"github.com/Mirantis/mcc/pkg/exec"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -36,6 +37,16 @@ func NewClientConfigCommand() *cli.Command {
 				Aliases: []string{"p"},
 				Hidden:  true,
 			},
+			&cli.BoolFlag{
+				Name:  "confirm",
+				Usage: "Ask confirmation for all commands",
+				Value: false,
+			},
+			&cli.BoolFlag{
+				Name:  "disable-redact",
+				Usage: "Do not hide sensitive information in the output",
+				Value: false,
+			},
 		},
 		Action: func(ctx *cli.Context) error {
 			product, err := config.ProductFromFile(ctx.String("config"))
@@ -53,6 +64,8 @@ func NewClientConfigCommand() *cli.Command {
 			return err
 		},
 		Before: func(ctx *cli.Context) error {
+			exec.Confirm = ctx.Bool("confirm")
+			exec.DisableRedact = ctx.Bool("disable-redact")
 			if strings.Contains(strings.Join(os.Args, " "), "download-bundle") {
 				log.Warn()
 				log.Warn("[DEPRECATED] The 'download-bundle' subcommand is now 'client-config'.")

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Mirantis/mcc/pkg/analytics"
 	"github.com/Mirantis/mcc/pkg/config"
+	"github.com/Mirantis/mcc/pkg/exec"
 	"github.com/urfave/cli/v2"
 	event "gopkg.in/segmentio/analytics-go.v3"
 
@@ -37,6 +38,16 @@ func NewDescribeCommand() *cli.Command {
 				Aliases:   []string{"c"},
 				Value:     "launchpad.yaml",
 				TakesFile: true,
+			},
+			&cli.BoolFlag{
+				Name:  "confirm",
+				Usage: "Ask confirmation for all commands",
+				Value: false,
+			},
+			&cli.BoolFlag{
+				Name:  "disable-redact",
+				Usage: "Do not hide sensitive information in the output",
+				Value: false,
 			},
 		},
 		Action: func(ctx *cli.Context) error {
@@ -74,6 +85,8 @@ func NewDescribeCommand() *cli.Command {
 			return err
 		},
 		Before: func(ctx *cli.Context) error {
+			exec.Confirm = ctx.Bool("confirm")
+			exec.DisableRedact = ctx.Bool("disable-redact")
 			if !ctx.Bool("accept-license") {
 				return analytics.RequireRegisteredUser()
 			}

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -8,6 +8,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/Mirantis/mcc/pkg/analytics"
 	"github.com/Mirantis/mcc/pkg/config"
+	"github.com/Mirantis/mcc/pkg/exec"
 	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
 	event "gopkg.in/segmentio/analytics-go.v3"
@@ -30,6 +31,16 @@ func NewResetCommand() *cli.Command {
 				Name:    "force",
 				Usage:   "Don't ask for confirmation",
 				Aliases: []string{"f"},
+			},
+			&cli.BoolFlag{
+				Name:  "confirm",
+				Usage: "Ask confirmation for all commands",
+				Value: false,
+			},
+			&cli.BoolFlag{
+				Name:  "disable-redact",
+				Usage: "Do not hide sensitive information in the output",
+				Value: false,
 			},
 		},
 		Action: func(ctx *cli.Context) error {
@@ -54,6 +65,8 @@ func NewResetCommand() *cli.Command {
 			return err
 		},
 		Before: func(ctx *cli.Context) error {
+			exec.Confirm = ctx.Bool("confirm")
+			exec.DisableRedact = ctx.Bool("disable-redact")
 			if !ctx.Bool("force") {
 				if !isatty.IsTerminal(os.Stdout.Fd()) {
 					return fmt.Errorf("reset requires --force")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,8 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/Mirantis/mcc/pkg/config/migration"
+	"github.com/Mirantis/mcc/pkg/exec"
+
 	// needed to load the migrators
 	_ "github.com/Mirantis/mcc/pkg/config/migration/v1beta1"
 	// needed to load the migrators
@@ -58,8 +60,13 @@ func productFromYAML(data []byte) (product.Product, error) {
 		return nil, err
 	}
 
-	re := regexp.MustCompile(`(username|password)([:= ]) ?\S+`)
-	log.Debugf("loaded configuration:\n%s", re.ReplaceAllString(string(plain), "$1$2[REDACTED]"))
+	cfg := string(plain)
+	if !exec.DisableRedact {
+		re := regexp.MustCompile(`(username|password)([:= ]) ?\S+`)
+		cfg = re.ReplaceAllString(cfg, "$1$2[REDACTED]")
+	}
+
+	log.Debugf("loaded configuration:\n%s", cfg)
 
 	switch c["kind"].(string) {
 	case "DockerEnterprise":


### PR DESCRIPTION
Eventually customers will ask "what does running this mysterious binary and providing it root access will do on my super secret system?"

This PR adds `--confirm` command flag that will make launchpad ask for confirmation for every remote command performed:

![image](https://user-images.githubusercontent.com/224971/99042798-0a1e1d80-2596-11eb-9d7d-a4bcd4d06a60.png)

This PR also adds a `--disable-redact` flag that will disable all censorship from the log output, meaning passwords, tokens, etc will be displayed in clear text instead of `[REDACTED]`.
