### PR TITLE
Update daemon.json also when not installing/upgrading engine

### DIFF
--- a/pkg/api/configurer.go
+++ b/pkg/api/configurer.go
@@ -15,6 +15,7 @@ type HostConfigurer interface {
 	InstallBasePackages() error
 	UpdateEnvironment() error
 	CleanupEnvironment() error
+	EngineConfigPath() string
 	InstallEngine(engineConfig *EngineConfig) error
 	UninstallEngine(engineConfig *EngineConfig) error
 	DockerCommandf(template string, args ...interface{}) string

--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -1,7 +1,6 @@
 package configurer
 
 import (
-	"encoding/json"
 	"fmt"
 	"path"
 	"regexp"
@@ -25,28 +24,13 @@ type LinuxConfigurer struct {
 // SbinPath is for adding sbin directories to current $PATH
 const SbinPath = `PATH=/usr/local/sbin:/usr/sbin:/sbin:$PATH`
 
+// EngineConfigPath returns the configuration file path
+func (c *LinuxConfigurer) EngineConfigPath() string {
+	return "/etc/docker/daemon.json"
+}
+
 // InstallEngine install Docker EE engine on Linux
 func (c *LinuxConfigurer) InstallEngine(engineConfig *api.EngineConfig) error {
-	if len(c.Host.DaemonConfig) > 0 {
-		daemonJSONData, err := json.Marshal(c.Host.DaemonConfig)
-		if err != nil {
-			return fmt.Errorf("failed to marshal daemon json config: %w", err)
-		}
-
-		cfg := "/etc/docker/daemon.json"
-		if c.FileExist(cfg) {
-			log.Debugf("deleting %s", cfg)
-			if err := c.DeleteFile(cfg); err != nil {
-				return err
-			}
-		}
-
-		log.Debugf("writing %s", cfg)
-		if err := c.WriteFile(cfg, string(daemonJSONData), "0700"); err != nil {
-			return err
-		}
-	}
-
 	if c.Host.Metadata.EngineVersion == engineConfig.Version {
 		return nil
 	}

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -1,7 +1,6 @@
 package configurer
 
 import (
-	"encoding/json"
 	"fmt"
 	"path"
 	"strconv"
@@ -31,28 +30,13 @@ func (c *WindowsConfigurer) Pwd() string {
 	return pwd
 }
 
+// EngineConfigPath returns the configuration file path
+func (c *WindowsConfigurer) EngineConfigPath() string {
+	return `C:\ProgramData\Docker\config\daemon.json`
+}
+
 // InstallEngine install Docker EE engine on Windows
 func (c *WindowsConfigurer) InstallEngine(engineConfig *api.EngineConfig) error {
-	if len(c.Host.DaemonConfig) > 0 {
-		daemonJSONData, err := json.Marshal(c.Host.DaemonConfig)
-		if err != nil {
-			return fmt.Errorf("failed to marshal daemon json config: %w", err)
-		}
-
-		cfg := `C:\ProgramData\Docker\config\daemon.json`
-		if c.FileExist(cfg) {
-			log.Debugf("deleting %s", cfg)
-			if err := c.DeleteFile(cfg); err != nil {
-				return err
-			}
-		}
-
-		log.Debugf("writing %s", cfg)
-		if err := c.WriteFile(cfg, string(daemonJSONData), "0700"); err != nil {
-			return err
-		}
-	}
-
 	if c.Host.Metadata.EngineVersion == engineConfig.Version {
 		return nil
 	}

--- a/pkg/product/mke/apply.go
+++ b/pkg/product/mke/apply.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Mirantis/mcc/pkg/api"
 	"github.com/Mirantis/mcc/pkg/phase"
 	common "github.com/Mirantis/mcc/pkg/product/common/phase"
-	de "github.com/Mirantis/mcc/pkg/product/mke/phase"
+	mke "github.com/Mirantis/mcc/pkg/product/mke/phase"
 	log "github.com/sirupsen/logrus"
 	event "gopkg.in/segmentio/analytics-go.v3"
 )
@@ -20,35 +20,38 @@ func (p *MKE) Apply(disableCleanup, force bool) error {
 
 	phaseManager.AddPhases(
 		&common.Connect{},
-		&de.GatherFacts{},
-		&de.ValidateFacts{Force: force},
-		&de.ValidateHosts{},
-		&de.DownloadInstaller{},
+		&mke.GatherFacts{},
+		&mke.ValidateFacts{Force: force},
+		&mke.ValidateHosts{},
+		&mke.DownloadInstaller{},
 		&common.RunHooks{Stage: "Before", Action: "Apply", StepListFunc: func(h *api.Host) *[]string { return h.Hooks.Apply.Before }},
-		&de.PrepareHost{},
-		&de.InstallEngine{},
-		&de.LoadImages{},
-		&de.AuthenticateDocker{},
-		&de.PullMKEImages{},
-		&de.InitSwarm{},
-		&de.InstallMKE{SkipCleanup: disableCleanup},
-		&de.UpgradeMKE{},
-		&de.JoinManagers{},
-		&de.JoinWorkers{},
+		&mke.PrepareHost{},
+		&mke.ConfigureEngine{},
+		&mke.InstallEngine{},
+		&mke.UpgradeEngine{},
+		&mke.RestartEngine{},
+		&mke.LoadImages{},
+		&mke.AuthenticateDocker{},
+		&mke.PullMKEImages{},
+		&mke.InitSwarm{},
+		&mke.InstallMKE{SkipCleanup: disableCleanup},
+		&mke.UpgradeMKE{},
+		&mke.JoinManagers{},
+		&mke.JoinWorkers{},
 
 		// begin MSR phases
-		&de.PullMSRImages{},
-		&de.ValidateMKEHealth{},
-		&de.InstallMSR{SkipCleanup: disableCleanup},
-		&de.UpgradeMSR{},
-		&de.JoinMSRReplicas{},
+		&mke.PullMSRImages{},
+		&mke.ValidateMKEHealth{},
+		&mke.InstallMSR{SkipCleanup: disableCleanup},
+		&mke.UpgradeMSR{},
+		&mke.JoinMSRReplicas{},
 		// end MSR phases
 
-		&de.LabelNodes{},
-		&de.RemoveNodes{},
+		&mke.LabelNodes{},
+		&mke.RemoveNodes{},
 		&common.RunHooks{Stage: "After", Action: "Apply", StepListFunc: func(h *api.Host) *[]string { return h.Hooks.Apply.After }},
 		&common.Disconnect{},
-		&de.Info{},
+		&mke.Info{},
 	)
 
 	if err := phaseManager.Run(); err != nil {

--- a/pkg/product/mke/phase/configure_engine.go
+++ b/pkg/product/mke/phase/configure_engine.go
@@ -1,0 +1,45 @@
+package phase
+
+import (
+	"github.com/Mirantis/mcc/pkg/api"
+	"github.com/Mirantis/mcc/pkg/phase"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// ConfigureEngine phase implementation
+type ConfigureEngine struct {
+	phase.Analytics
+	phase.HostSelectPhase
+}
+
+// HostFilterFunc returns true for hosts that need their engine to be restarted
+func (p *ConfigureEngine) HostFilterFunc(h *api.Host) bool {
+	return len(h.DaemonConfig) > 0
+}
+
+// Prepare collects the hosts
+func (p *ConfigureEngine) Prepare(config *api.ClusterConfig) error {
+	p.Config = config
+	log.Debugf("collecting hosts for phase %s", p.Title())
+	hosts := config.Spec.Hosts.Filter(p.HostFilterFunc)
+	log.Debugf("found %d hosts for phase %s", len(hosts), p.Title())
+	p.Hosts = hosts
+	return nil
+}
+
+// Title for the phase
+func (p *ConfigureEngine) Title() string {
+	return "Configure Docker EE Engine on the hosts"
+}
+
+// Run installs the engine on each host
+func (p *ConfigureEngine) Run() error {
+	p.EventProperties = map[string]interface{}{
+		"engine_version": p.Config.Spec.Engine.Version,
+	}
+	return p.Hosts.ParallelEach(func(h *api.Host) error {
+		log.Infof("%s: configuring engine", h)
+		return h.ConfigureEngine()
+	})
+}

--- a/pkg/product/mke/phase/restart_engine.go
+++ b/pkg/product/mke/phase/restart_engine.go
@@ -1,0 +1,91 @@
+package phase
+
+import (
+	"math"
+	"sync"
+
+	"github.com/Mirantis/mcc/pkg/api"
+	"github.com/Mirantis/mcc/pkg/phase"
+
+	"github.com/gammazero/workerpool"
+	log "github.com/sirupsen/logrus"
+)
+
+// RestartEngine phase implementation
+type RestartEngine struct {
+	phase.Analytics
+	phase.HostSelectPhase
+}
+
+// HostFilterFunc returns true for hosts that need their engine to be restarted
+func (p *RestartEngine) HostFilterFunc(h *api.Host) bool {
+	return h.Metadata.EngineRestartRequired
+}
+
+// Prepare collects the hosts
+func (p *RestartEngine) Prepare(config *api.ClusterConfig) error {
+	p.Config = config
+	log.Debugf("collecting hosts for phase %s", p.Title())
+	hosts := config.Spec.Hosts.Filter(p.HostFilterFunc)
+	log.Debugf("found %d hosts for phase %s", len(hosts), p.Title())
+	p.Hosts = hosts
+	return nil
+}
+
+// Title for the phase
+func (p *RestartEngine) Title() string {
+	return "Restart Docker EE Engine on the hosts"
+}
+
+// Run installs the engine on each host
+func (p *RestartEngine) Run() error {
+	p.EventProperties = map[string]interface{}{
+		"engine_version": p.Config.Spec.Engine.Version,
+	}
+	return p.restartEngines()
+}
+
+// Restarts host docker engines, first managers (one-by-one) and then ~10% rolling update to workers
+func (p *RestartEngine) restartEngines() error {
+	var managers api.Hosts
+	var others api.Hosts
+	for _, h := range p.Hosts {
+		if h.Role == "manager" {
+			managers = append(managers, h)
+		} else {
+			others = append(others, h)
+		}
+	}
+
+	for _, h := range managers {
+		if err := h.Configurer.RestartEngine(); err != nil {
+			return err
+		}
+	}
+
+	// restart in 10% chunks
+	concurrentRestarts := int(math.Floor(float64(len(others)) * 0.10))
+	if concurrentRestarts == 0 {
+		concurrentRestarts = 1
+	}
+	wp := workerpool.New(concurrentRestarts)
+	mu := sync.Mutex{}
+	restartErrors := &phase.Error{}
+	for _, w := range others {
+		h := w
+		wp.Submit(func() {
+			err := h.Configurer.RestartEngine()
+			if err != nil {
+				mu.Lock()
+				restartErrors.Errors = append(restartErrors.Errors, err)
+				mu.Unlock()
+			}
+			h.Metadata.EngineRestartRequired = false
+		})
+	}
+	wp.StopWait()
+	if restartErrors.Count() > 0 {
+		return restartErrors
+	}
+	return nil
+}

--- a/pkg/product/mke/phase/upgrade_engine.go
+++ b/pkg/product/mke/phase/upgrade_engine.go
@@ -1,0 +1,146 @@
+package phase
+
+import (
+	"fmt"
+	"math"
+	"sync"
+
+	"github.com/Mirantis/mcc/pkg/api"
+	"github.com/Mirantis/mcc/pkg/phase"
+
+	retry "github.com/avast/retry-go"
+	"github.com/gammazero/workerpool"
+	log "github.com/sirupsen/logrus"
+)
+
+// UpgradeEngine phase implementation
+type UpgradeEngine struct {
+	phase.Analytics
+	phase.HostSelectPhase
+}
+
+// HostFilterFunc returns true for hosts that do not have engine installed
+func (p *UpgradeEngine) HostFilterFunc(h *api.Host) bool {
+	return h.Metadata.EngineVersion != p.Config.Spec.Engine.Version
+}
+
+// Prepare collects the hosts
+func (p *UpgradeEngine) Prepare(config *api.ClusterConfig) error {
+	p.Config = config
+	log.Debugf("collecting hosts for phase %s", p.Title())
+	hosts := config.Spec.Hosts.Filter(p.HostFilterFunc)
+	log.Debugf("found %d hosts for phase %s", len(hosts), p.Title())
+	p.Hosts = hosts
+	return nil
+}
+
+// Title for the phase
+func (p *UpgradeEngine) Title() string {
+	return "Upgrade Docker EE Engine on the hosts"
+}
+
+// Run installs the engine on each host
+func (p *UpgradeEngine) Run() error {
+	p.EventProperties = map[string]interface{}{
+		"engine_version": p.Config.Spec.Engine.Version,
+	}
+	return p.upgradeEngines()
+}
+
+// Upgrades host docker engines, first managers (one-by-one) and then ~10% rolling update to workers
+// TODO: should we drain?
+func (p *UpgradeEngine) upgradeEngines() error {
+	var managers api.Hosts
+	var others api.Hosts
+	for _, h := range p.Hosts {
+		if h.Role == "manager" {
+			managers = append(managers, h)
+		} else {
+			others = append(others, h)
+		}
+	}
+
+	for _, h := range managers {
+		err := p.upgradeEngine(h)
+		if err != nil {
+			return err
+		}
+		if p.Config.Spec.MKE.Metadata.Installed {
+			err := p.Config.Spec.CheckMKEHealthLocal(h)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// sacrifice 10% of workers for upgrade gods
+	concurrentUpgrades := int(math.Floor(float64(len(others)) * 0.10))
+	if concurrentUpgrades == 0 {
+		concurrentUpgrades = 1
+	}
+	wp := workerpool.New(concurrentUpgrades)
+	mu := sync.Mutex{}
+	installErrors := &phase.Error{}
+	for _, w := range others {
+		h := w
+		wp.Submit(func() {
+			err := p.upgradeEngine(h)
+			if err != nil {
+				mu.Lock()
+				installErrors.Errors = append(installErrors.Errors, err)
+				mu.Unlock()
+			}
+		})
+	}
+	wp.StopWait()
+	if installErrors.Count() > 0 {
+		return installErrors
+	}
+	return nil
+}
+
+func (p *UpgradeEngine) upgradeEngine(h *api.Host) error {
+	err := retry.Do(
+		func() error {
+			log.Infof("%s: upgrading engine (%s -> %s)", h, h.Metadata.EngineVersion, p.Config.Spec.Engine.Version)
+			return h.Configurer.InstallEngine(&p.Config.Spec.Engine)
+		},
+	)
+	if err != nil {
+		log.Errorf("%s: failed to update engine -> %s", h, err.Error())
+		return err
+	}
+
+	// TODO: This excercise is duplicated in InstallEngine, maybe
+	// combine into some kind of "EnsureVersion"
+	currentVersion, err := h.EngineVersion()
+	if err != nil {
+		if err := h.Reboot(); err != nil {
+			return err
+		}
+		currentVersion, err = h.EngineVersion()
+		if err != nil {
+			return fmt.Errorf("%s: failed to query engine version after installation: %s", h, err.Error())
+		}
+	}
+
+	if currentVersion != p.Config.Spec.Engine.Version {
+		err = h.Configurer.RestartEngine()
+		if err != nil {
+			return fmt.Errorf("%s: failed to restart engine", h)
+		}
+		currentVersion, err = h.EngineVersion()
+		if err != nil {
+			return fmt.Errorf("%s: failed to query engine version after restart: %s", h, err.Error())
+		}
+	}
+
+	if currentVersion != p.Config.Spec.Engine.Version {
+		return fmt.Errorf("%s: engine version not %s after upgrade", h, p.Config.Spec.Engine.Version)
+	}
+
+	log.Infof("%s: upgraded to engine version %s", h, p.Config.Spec.Engine.Version)
+	h.Metadata.EngineVersion = p.Config.Spec.Engine.Version
+	h.Metadata.EngineRestartRequired = false
+	return nil
+}


### PR DESCRIPTION
As noted by @dockerpac on slack, the engine config is not updated except when installing or upgrading the engine.

This PR splits the engine business into multiple phases:

1. configure (parallel)
2. install (parallel)
3. upgrade (managers individually, then others parallelly)
4. restart (same as above)

Previously the installations and upgrades were done parallelly together, now first comes installs to all hosts, then upgrades and finally restarts (should only happen on hosts that where engine was not installed or upgraded but the config was changed)

Each of the phases is only run for hosts that need it.
