### PR TITLE
Upgrade engines on MSR hosts individually to avoid downtime

### DIFF
--- a/pkg/product/mke/phase/upgrade_engine.go
+++ b/pkg/product/mke/phase/upgrade_engine.go
@@ -59,7 +59,7 @@ func (p *UpgradeEngine) upgradeEngines() error {
 		switch h.Role {
 		case "manager":
 			managers = append(managers, h)
-		case "workers":
+		case "worker":
 			workers = append(workers, h)
 		case "msr":
 			msrs = append(msrs, h)


### PR DESCRIPTION
Currently it is quite easy to end up in a situation where all the MSR hosts are down simultaneously during the upgrade.

(for example, with 18 worker nodes and 2 msr nodes, when performing the upgrades in 10% chunks, the two msr nodes will be upgraded simultaneously)

This PR changes the engine upgrades on MSR hosts happen individually like it is already done for the managers. After the upgrade a healthcheck is performed, if the MSR did not resume, the upgrade process will be halted.

I doubt anyone has so many MSR hosts that running the upgrades in 10% batches like for the MKE workers would make much change in process duration.
 
(reported by @mgueye01 on slack)

