### PR TITLE
Ignore MSR configuration when no MSR hosts present

### DIFF
--- a/pkg/product/mke/api/cluster.go
+++ b/pkg/product/mke/api/cluster.go
@@ -50,9 +50,6 @@ func roleChecks(sl validator.StructLevel) {
 	if hosts.Count(func(h *Host) bool { return h.Role == "manager" }) == 0 {
 		sl.ReportError(hosts, "hosts", "", "manager required", "")
 	}
-	if spec.MSR != nil && hosts.Count(func(h *Host) bool { return h.Role == "msr" }) == 0 {
-		sl.ReportError(hosts, "hosts", "", "spec.msr configuration present but there are no hosts with role=msr", "")
-	}
 }
 
 // Init returns an example of configuration file contents

--- a/pkg/product/mke/api/cluster_spec.go
+++ b/pkg/product/mke/api/cluster_spec.go
@@ -166,6 +166,11 @@ func (c *ClusterSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
+	if yc.MSR != nil && yc.Hosts.Count(func(h *Host) bool { return h.Role == "msr" }) == 0 {
+		yc.MSR = nil
+		log.Debugf("ignoring spec.msr configuration as there are no hosts having the msr role")
+	}
+
 	c.Engine.SetDefaults()
 
 	return nil


### PR DESCRIPTION
Probably more failsafe than #266 and more convenient than #268

@quadespresso would be happier with the ignoring instead of erroring.
