### PR TITLE
Clean up empty hooks from config dumps

### DIFF
--- a/pkg/product/common/api/hooks.go
+++ b/pkg/product/common/api/hooks.go
@@ -2,12 +2,12 @@ package api
 
 // BeforeAfter is the a child struct for the Hooks struct, containing sections for Before and After
 type BeforeAfter struct {
-	Before *[]string `yaml:"before" default:"[]"`
-	After  *[]string `yaml:"after" default:"[]"`
+	Before *[]string `yaml:"before,omitempty"`
+	After  *[]string `yaml:"after,omitempty"`
 }
 
 // Hooks is a list of hook-points
 type Hooks struct {
-	Apply *BeforeAfter `yaml:"apply" default:"{}"`
-	Reset *BeforeAfter `yaml:"reset" default:"{}"`
+	Apply *BeforeAfter `yaml:"apply,omitempty"`
+	Reset *BeforeAfter `yaml:"reset,omitempty"`
 }

--- a/pkg/product/mke/api/host.go
+++ b/pkg/product/mke/api/host.go
@@ -71,7 +71,7 @@ type Host struct {
 	PrivateInterface string             `yaml:"privateInterface,omitempty" validate:"omitempty,gt=2"`
 	DaemonConfig     common.GenericHash `yaml:"engineConfig,flow,omitempty" default:"{}"`
 	Environment      map[string]string  `yaml:"environment,flow,omitempty" default:"{}"`
-	Hooks            *common.Hooks      `yaml:"hooks,omitempty" default:"{}"`
+	Hooks            *common.Hooks      `yaml:"hooks,omitempty"`
 	ImageDir         string             `yaml:"imageDir,omitempty"`
 
 	WinRM     *common.WinRM `yaml:"winRM,omitempty"`

--- a/pkg/product/mke/apply.go
+++ b/pkg/product/mke/apply.go
@@ -24,7 +24,12 @@ func (p *MKE) Apply(disableCleanup, force bool) error {
 		&mke.ValidateFacts{Force: force},
 		&mke.ValidateHosts{},
 		&mke.DownloadInstaller{},
-		&common.RunHooks{Stage: "Before", Action: "Apply", StepListFunc: func(h *api.Host) *[]string { return h.Hooks.Apply.Before }},
+		&common.RunHooks{Stage: "Before", Action: "Apply", StepListFunc: func(h *api.Host) *[]string {
+			if h.Hooks == nil || h.Hooks.Apply == nil || h.Hooks.Apply.Before == nil {
+				return &[]string{}
+			}
+			return h.Hooks.Apply.Before
+		}},
 		&mke.PrepareHost{},
 		&mke.ConfigureEngine{},
 		&mke.InstallEngine{},
@@ -49,7 +54,12 @@ func (p *MKE) Apply(disableCleanup, force bool) error {
 
 		&mke.LabelNodes{},
 		&mke.RemoveNodes{},
-		&common.RunHooks{Stage: "After", Action: "Apply", StepListFunc: func(h *api.Host) *[]string { return h.Hooks.Apply.After }},
+		&common.RunHooks{Stage: "After", Action: "Apply", StepListFunc: func(h *api.Host) *[]string {
+			if h.Hooks == nil || h.Hooks.Apply == nil || h.Hooks.Apply.After == nil {
+				return &[]string{}
+			}
+			return h.Hooks.Apply.After
+		}},
 		&common.Disconnect{},
 		&mke.Info{},
 	)

--- a/pkg/product/mke/phase/join_msr_replicas.go
+++ b/pkg/product/mke/phase/join_msr_replicas.go
@@ -17,7 +17,7 @@ type JoinMSRReplicas struct {
 	phase.HostSelectPhase
 }
 
-// HostFilterFunc returns true for hosts that have non-empty list of hooks returned by the StepListFunc
+// HostFilterFunc returns true for hosts that don't have MSR configured
 func (p *JoinMSRReplicas) HostFilterFunc(h *api.Host) bool {
 	return h.MSRMetadata == nil || !h.MSRMetadata.Installed
 }

--- a/pkg/product/mke/phase/upload_images.go
+++ b/pkg/product/mke/phase/upload_images.go
@@ -25,7 +25,7 @@ func (p *LoadImages) Title() string {
 	return "Upload images"
 }
 
-// HostFilterFunc returns true for hosts that have non-empty list of hooks returned by the StepListFunc
+// HostFilterFunc returns true for hosts that have images to be uploaded
 func (p *LoadImages) HostFilterFunc(h *api.Host) bool {
 	if h.ImageDir == "" {
 		return false

--- a/pkg/product/mke/reset.go
+++ b/pkg/product/mke/reset.go
@@ -14,7 +14,12 @@ func (p *MKE) Reset() error {
 	phaseManager.AddPhases(
 		&common.Connect{},
 		&mke.GatherFacts{},
-		&common.RunHooks{Stage: "Before", Action: "Reset", StepListFunc: func(h *api.Host) *[]string { return h.Hooks.Reset.Before }},
+		&common.RunHooks{Stage: "Before", Action: "Reset", StepListFunc: func(h *api.Host) *[]string {
+			if h.Hooks == nil || h.Hooks.Reset == nil || h.Hooks.Reset.Before == nil {
+				return &[]string{}
+			}
+			return h.Hooks.Reset.Before
+		}},
 
 		// begin MSR phases
 		&mke.UninstallMSR{},
@@ -24,7 +29,13 @@ func (p *MKE) Reset() error {
 		&mke.DownloadInstaller{},
 		&mke.UninstallEngine{},
 		&mke.CleanUp{},
-		&common.RunHooks{Stage: "After", Action: "Reset", StepListFunc: func(h *api.Host) *[]string { return h.Hooks.Reset.After }},
+		&common.RunHooks{Stage: "After", Action: "Reset", StepListFunc: func(h *api.Host) *[]string {
+			if h.Hooks == nil || h.Hooks.Reset == nil || h.Hooks.Reset.After == nil {
+				return &[]string{}
+			}
+
+			return h.Hooks.Reset.After
+		}},
 		&common.Disconnect{},
 	)
 


### PR DESCRIPTION
Don't create empty default hooks structures to avoid cluttering config dumps.

Before:

```yaml
# launchpad describe config
apiVersion: launchpad.mirantis.com/mke/v1.1
kind: mke+msr
metadata:
  name: launchpad-mke
spec:
  hosts:
  - address: 127.0.0.1
    role: manager
    hooks:
      apply:
        before: []
        after: []
      reset:
        before: []
        after: []
  - address: 127.0.0.1
    role: msr
    hooks:
      apply:
        before: []
        after: []
      reset:
        before: []
        after: []
```

After:

```yaml
# launchpad describe config
apiVersion: launchpad.mirantis.com/mke/v1.1
kind: mke+msr
metadata:
  name: launchpad-mke
spec:
  hosts:
  - address: 127.0.0.1
    role: manager
  - address: 127.0.0.1
    role: msr
```
