### PR TITLE
Fix RHEL selinux engine setting

### DIFF
--- a/pkg/configurer/enterpriselinux/el.go
+++ b/pkg/configurer/enterpriselinux/el.go
@@ -41,10 +41,6 @@ func (c *Configurer) UninstallEngine(engineConfig *api.EngineConfig) error {
 
 // InstallEngine install Docker EE engine on Linux
 func (c *Configurer) InstallEngine(engineConfig *api.EngineConfig) error {
-	if c.SELinuxEnabled() {
-		c.Host.DaemonConfig["selinux-enabled"] = true
-	}
-
 	if c.Host.Exec("sudo dmidecode -s system-manufacturer|grep -q EC2") == nil {
 		if c.Host.Exec("sudo yum install -q -y rh-amazon-rhui-client") == nil {
 			log.Infof("%s: appears to be an AWS EC2 instance, installed rh-amazon-rhui-client", c.Host)

--- a/pkg/product/mke/phase/validate_facts.go
+++ b/pkg/product/mke/phase/validate_facts.go
@@ -29,6 +29,15 @@ func (p *ValidateFacts) Run() error {
 		p.populateSan()
 	}
 
+	p.Config.Spec.Hosts.Each(func(h *api.Host) error {
+		if h.Configurer != nil && h.Configurer.SELinuxEnabled() {
+			h.DaemonConfig["selinux-enabled"] = true
+			log.Infof("%s: adding 'selinux-enabled=true' to host engine config", h)
+		}
+
+		return nil
+	})
+
 	if err := p.validateMKEVersionJump(p.Config); err != nil {
 		if p.Force {
 			log.Warnf("%s - continuing anyway because --force given", err.Error())


### PR DESCRIPTION
Taken from #274 - just fixes the selinux docker engine setting enabling that was assumedly broken by 1.1.0

It was done in the "install engine" phase, but the engine configuration is written before that. This PR moves the enabling to the validate facts phase, which happens before Configure engine.
