### PR TITLE
Preliminary SLES support

### DIFF
--- a/pkg/configurer/sles/sles.go
+++ b/pkg/configurer/sles/sles.go
@@ -1,0 +1,55 @@
+package sles
+
+import (
+	"github.com/Mirantis/mcc/pkg/configurer"
+	"github.com/Mirantis/mcc/pkg/configurer/resolver"
+	common "github.com/Mirantis/mcc/pkg/product/common/api"
+)
+
+// Configurer is a generic Ubuntu level configurer implementation. Some of the configurer interface implementation
+// might be on OS version specific implementation such as for Bionic.
+type Configurer struct {
+	configurer.LinuxConfigurer
+}
+
+// InstallMKEBasePackages installs the needed base packages on Ubuntu
+func (c *Configurer) InstallMKEBasePackages() error {
+	err := c.FixContainerizedHost()
+	if err != nil {
+		return err
+	}
+	return c.Host.Exec("sudo zypper -n install -y curl socat")
+}
+
+// UninstallEngine uninstalls docker-ee engine
+func (c *Configurer) UninstallEngine(scriptPath string, engineConfig common.EngineConfig) error {
+	err := c.Host.Exec("sudo docker system prune -f")
+	if err != nil {
+		return err
+	}
+	err = c.Host.Exec("sudo systemctl stop docker")
+	if err != nil {
+		return err
+	}
+	err = c.Host.Exec("sudo systemctl stop containerd")
+	if err != nil {
+		return err
+	}
+	return c.Host.Exec("sudo zypper -n remove -y --clean-deps docker-ee docker-ee-cli")
+}
+
+func resolveSLESConfigurer(h configurer.Host, os *common.OsRelease) interface{} {
+	if os.ID == "sles" {
+		return &Configurer{
+			LinuxConfigurer: configurer.LinuxConfigurer{
+				Host: h,
+			},
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	resolver.RegisterHostConfigurer(resolveSLESConfigurer)
+}

--- a/pkg/product/mke/phase/gather_facts.go
+++ b/pkg/product/mke/phase/gather_facts.go
@@ -20,6 +20,8 @@ import (
 	// needed to load the build func in package init
 	_ "github.com/Mirantis/mcc/pkg/configurer/oracle"
 	// needed to load the build func in package init
+	_ "github.com/Mirantis/mcc/pkg/configurer/sles"
+	// needed to load the build func in package init
 	_ "github.com/Mirantis/mcc/pkg/configurer/windows"
 	"github.com/cobaugh/osrelease"
 	log "github.com/sirupsen/logrus"


### PR DESCRIPTION
Managed to install a manager+worker MKE using the default SLES AMI which AWS offers on the launch instance screen:

![image](https://user-images.githubusercontent.com/224971/102469319-43e1b880-405b-11eb-8df8-4a76efd6143c.png)

Had to modify the security group to allow traffic between the hosts.
