### PR TITLE
Add MKE and MSR upgradeFlags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,15 +197,15 @@ pipeline {
                 sh "make smoke-test"
               }
             }
-            stage("Upgrade MKE3.3.4 MSR2.8.5-0a43eee0 ENG19.03.13 from private repos") {
+            stage("Upgrade MKE3.3.5-beta MSR2.8.5-beta ENG19.03.13 from private repos") {
               environment {
                 LINUX_IMAGE = "quay.io/footloose/ubuntu18.04"
                 FOOTLOOSE_TEMPLATE = "footloose-msr.yaml.tpl"
-                LAUNCHPAD_CONFIG = "launchpad-msr.yaml"
-                MKE_VERSION = "3.3.4"
+                LAUNCHPAD_CONFIG = "launchpad-msr-beta.yaml"
+                MKE_VERSION = "3.3.5-d1da376"
                 MKE_IMAGE_REPO = "docker.io/mirantiseng"
                 MSR_IMAGE_REPO = "docker.io/mirantiseng"
-                MSR_VERSION = "2.8.5-0a43eee0"
+                MSR_VERSION = "2.8.5-rc1"
                 ENGINE_VERSION = "19.03.13"
                 REUSE_CLUSTER = "true"
                 PRESERVE_CLUSTER = "true"
@@ -217,50 +217,6 @@ pipeline {
                   sh "make smoke-reset-test"
                   sh "make smoke-cleanup"
                 }
-              }
-            }
-          }
-        }
-        stage("Ubuntu 18.04 with MSR and custom repository") {
-          agent {
-            node {
-              label 'amd64 && ubuntu-1804 && overlay2 && big'
-            }
-          }
-          stages {
-            stage("Install MKE3.2 MSR2.7 ENG19.03.8") {
-              environment {
-                LINUX_IMAGE = "quay.io/footloose/ubuntu18.04"
-                FOOTLOOSE_TEMPLATE = "footloose-msr.yaml.tpl"
-                LAUNCHPAD_CONFIG = "launchpad-msr.yaml"
-                MKE_VERSION = "3.2.8"
-                MKE_IMAGE_REPO = "docker.io/mirantis"
-                MSR_VERSION = "2.7.8"
-                MSR_IMAGE_REPO = "docker.io/mirantis"
-                ENGINE_VERSION = "19.03.8"
-                PRESERVE_CLUSTER = "true"
-              }
-              steps {
-                sh "make smoke-apply-local-repo-test"
-              }
-            }
-            stage("Upgrade MKE3.3 MSR2.8 ENG19.03.13") {
-              environment {
-                LINUX_IMAGE = "quay.io/footloose/ubuntu18.04"
-                FOOTLOOSE_TEMPLATE = "footloose-msr.yaml.tpl"
-                LAUNCHPAD_CONFIG = "launchpad-msr.yaml"
-                MKE_VERSION = "3.3.4"
-                MKE_IMAGE_REPO = "docker.io/mirantis"
-                MSR_IMAGE_REPO = "docker.io/mirantis"
-                MSR_VERSION = "2.8.4"
-                ENGINE_VERSION = "19.03.13"
-                REUSE_CLUSTER = "true"
-                PRESERVE_CLUSTER = "true"
-              }
-              steps {
-                sh "make smoke-apply-local-repo-test"
-                sh "make smoke-reset-local-repo-test"
-                sh "make smoke-cleanup"
               }
             }
           }

--- a/pkg/product/mke/api/mke_config.go
+++ b/pkg/product/mke/api/mke_config.go
@@ -18,6 +18,7 @@ type MKEConfig struct {
 	AdminUsername   string       `yaml:"adminUsername,omitempty"`
 	AdminPassword   string       `yaml:"adminPassword,omitempty"`
 	InstallFlags    common.Flags `yaml:"installFlags,omitempty,flow"`
+	UpgradeFlags    common.Flags `yaml:"upgradeFlags,omitempty,flow"`
 	ConfigFile      string       `yaml:"configFile,omitempty" validate:"omitempty,file"`
 	ConfigData      string       `yaml:"configData,omitempty"`
 	LicenseFilePath string       `yaml:"licenseFilePath,omitempty" validate:"omitempty,file"`
@@ -92,6 +93,24 @@ func (c *MKEConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			raw.InstallFlags.Delete("--admin-password")
 		} else if flagValue != raw.AdminPassword {
 			return fmt.Errorf("both Spec.mke.AdminPassword and Spec.mke.InstallFlags --admin-password set, only one allowed")
+		}
+	}
+
+	if flagValue := raw.UpgradeFlags.GetValue("--admin-username"); flagValue != "" {
+		if raw.AdminUsername == "" {
+			raw.AdminUsername = flagValue
+			raw.UpgradeFlags.Delete("--admin-username")
+		} else if flagValue != raw.AdminUsername {
+			return fmt.Errorf("both Spec.mke.AdminUsername and Spec.mke.UpgradeFlags --admin-username set, only one allowed")
+		}
+	}
+
+	if flagValue := raw.UpgradeFlags.GetValue("--admin-password"); flagValue != "" {
+		if raw.AdminPassword == "" {
+			raw.AdminPassword = flagValue
+			raw.UpgradeFlags.Delete("--admin-password")
+		} else if flagValue != raw.AdminPassword {
+			return fmt.Errorf("both Spec.mke.AdminPassword and Spec.mke.UpgradeFlags --admin-password set, only one allowed")
 		}
 	}
 

--- a/pkg/product/mke/api/msr_config.go
+++ b/pkg/product/mke/api/msr_config.go
@@ -14,6 +14,7 @@ type MSRConfig struct {
 	Version      string       `yaml:"version"`
 	ImageRepo    string       `yaml:"imageRepo,omitempty"`
 	InstallFlags common.Flags `yaml:"installFlags,flow,omitempty"`
+	UpgradeFlags common.Flags `yaml:"upgradeFlags,flow,omitempty"`
 	ReplicaIDs   string       `yaml:"replicaIDs,omitempty"  default:"random"`
 }
 

--- a/pkg/product/mke/phase/upgrade_mke.go
+++ b/pkg/product/mke/phase/upgrade_mke.go
@@ -39,7 +39,7 @@ func (p *UpgradeMKE) Run() error {
 	if swarmLeader.Configurer.SELinuxEnabled() {
 		runFlags.Add("--security-opt label=disable")
 	}
-	upgradeCmd := swarmLeader.Configurer.DockerCommandf("run %s %s upgrade --id %s", runFlags.Join(), p.Config.Spec.MKE.GetBootstrapperImage(), swarmClusterID)
+	upgradeCmd := swarmLeader.Configurer.DockerCommandf("run %s %s upgrade --id %s %s", runFlags.Join(), p.Config.Spec.MKE.GetBootstrapperImage(), swarmClusterID, p.Config.Spec.MKE.UpgradeFlags.Join())
 	err := swarmLeader.Exec(upgradeCmd, exec.StreamOutput())
 	if err != nil {
 		return fmt.Errorf("failed to run MKE upgrade")

--- a/pkg/product/mke/phase/upgrade_msr.go
+++ b/pkg/product/mke/phase/upgrade_msr.go
@@ -56,6 +56,7 @@ func (p *UpgradeMSR) Run() error {
 	for _, f := range msr.PluckSharedInstallFlags(p.Config.Spec.MSR.InstallFlags, msr.SharedInstallUpgradeFlags) {
 		upgradeFlags.AddOrReplace(f)
 	}
+	upgradeFlags.MergeOverwrite(p.Config.Spec.MSR.UpgradeFlags)
 
 	upgradeCmd := h.Configurer.DockerCommandf("run %s %s upgrade %s", runFlags.Join(), p.Config.Spec.MSR.GetBootstrapperImage(), upgradeFlags.Join())
 	log.Debugf("%s: Running msr upgrade via bootstrapper", h)

--- a/test/launchpad-msr-beta.yaml
+++ b/test/launchpad-msr-beta.yaml
@@ -1,0 +1,64 @@
+apiVersion: launchpad.mirantis.com/mke/v1.1
+kind: mke+msr
+metadata:
+  name: $CLUSTER_NAME
+spec:
+  hosts:
+    - address: "127.0.0.1"
+      ssh:
+        port: 9022
+        keyPath: "./id_rsa_launchpad"
+        user: "root"
+      role: "manager"
+      engineConfig: &engineCfg
+        "insecure-registries":
+          - 172.16.86.100:5000
+    - address: "127.0.0.1"
+      ssh:
+        port: 9023
+        keyPath: "./id_rsa_launchpad"
+        user: "root"
+      role: "worker"
+      engineConfig: *engineCfg
+    - address: "127.0.0.1"
+      ssh:
+        port: 9024
+        keyPath: "./id_rsa_launchpad"
+        user: "root"
+      role: "msr"
+      engineConfig: *engineCfg
+    - address: "127.0.0.1" # REMOVE_THIS
+      ssh: # REMOVE_THIS
+        port: 9025 # REMOVE_THIS
+        keyPath: "./id_rsa_launchpad" # REMOVE_THIS
+        user: "root" # REMOVE_THIS
+      role: "msr" # REMOVE_THIS
+      engineConfig: *engineCfg # REMOVE_THIS
+  cluster:
+    prune: false
+  mke:
+    version: $MKE_VERSION
+    imageRepo: $MKE_IMAGE_REPO
+    configData: |-
+      [scheduling_configuration]
+        default_node_orchestrator = "kubernetes"
+        enable_admin_ucp_scheduling = true
+    installFlags:
+      - --admin-username=admin
+      - --admin-password=orcaorcaorca
+    upgradeFlags:
+      - --force-minimums
+      - --force-recent-backup
+  engine:
+    version: $ENGINE_VERSION
+  msr:
+    version: $MSR_VERSION
+    imageRepo: $MSR_IMAGE_REPO
+    installFlags:
+      - --ucp-url $MKE_MANAGER_IP
+      - --ucp-insecure-tls
+      - --replica-http-port 81
+      - --replica-https-port 444
+    upgradeFlags:
+      - --debug
+    replicaIDs: sequential


### PR DESCRIPTION
Adds separate upgrade flags for MKE and MSR, because you may want to use the force or debug flags.

Requires an API version bump.

Example:

```yaml
spec:
  mke:
    installFlags:
      - --admin-username foo
    upgradeFlags:
      - --force-minimums
  msr:
    upgradeFlags:
      - --debug
```

Added the latest beta of both to upgrade smoketest.
