### PR TITLE
Use -NoProfile in powershell commands

### DIFF
--- a/pkg/connection/ssh/upload.go
+++ b/pkg/connection/ssh/upload.go
@@ -57,7 +57,7 @@ func (c *Connection) uploadLinux(src, dst string) error {
 }
 
 func (c *Connection) uploadWindows(src, dst string) error {
-	psCmd := ps.UploadCmd(dst)
+	psCmd := ps.Cmd(ps.UploadCmd(dst))
 	stat, err := os.Stat(src)
 	if err != nil {
 		return err
@@ -98,8 +98,7 @@ func (c *Connection) uploadWindows(src, dst string) error {
 		return err
 	}
 
-	psRunCmd := "powershell -ExecutionPolicy Unrestricted -EncodedCommand " + psCmd
-	if err := session.Start(psRunCmd); err != nil {
+	if err := session.Start(psCmd); err != nil {
 		return err
 	}
 

--- a/pkg/connection/winrm/upload.go
+++ b/pkg/connection/winrm/upload.go
@@ -24,7 +24,7 @@ import (
 // Upload uploads a file to a host
 // Adapted from https://github.com/jbrekelmans/go-winrm/copier.go by Jasper Brekelmans
 func (c *Connection) Upload(src, dst string) error {
-	psCmd := ps.UploadCmd(dst)
+	psCmd := ps.Cmd(ps.UploadCmd(dst))
 	stat, err := os.Stat(src)
 	if err != nil {
 		return err
@@ -52,7 +52,7 @@ func (c *Connection) Upload(src, dst string) error {
 	}
 	defer shell.Close()
 	log.Tracef("%s: running %s", c, psCmd)
-	cmd, err := shell.Execute("powershell -ExecutionPolicy Unrestricted -EncodedCommand " + psCmd)
+	cmd, err := shell.Execute(psCmd)
 	if err != nil {
 		return err
 	}

--- a/pkg/powershell/powershell.go
+++ b/pkg/powershell/powershell.go
@@ -1,4 +1,4 @@
-package util
+package powershell
 
 import (
 	"encoding/base64"
@@ -60,7 +60,7 @@ func Cmd(psCmd string) string {
 
 	log.Debugf("encoded powershell command: %s", psCmd)
 	// Create the powershell.exe command line to execute the script
-	return fmt.Sprintf("powershell.exe -NonInteractive -NoProfile -EncodedCommand %s", encodedCmd)
+	return fmt.Sprintf("powershell.exe -NonInteractive -ExecutionPolicy Bypass -NoProfile -EncodedCommand %s", encodedCmd)
 }
 
 // SingleQuote quotes and escapes a string in a format that is accepted by powershell scriptlets


### PR DESCRIPTION
Makes powershell commands add `-NoProfile` to the powershell parameters to avoid `<AV>Preparing modules for first use.</AV>` in stderr.

A lot of commands that were using direct `powershell ... "foofoo"` were changed to go through the `ps.Cmd` function.
