### PR TITLE
PRODENG-915 Ubuntu Focal (20.04) configurator

### DIFF
--- a/pkg/configurer/ubuntu/focal.go
+++ b/pkg/configurer/ubuntu/focal.go
@@ -1,0 +1,6 @@
+package ubuntu
+
+// FocalConfigurer is the Ubuntu Focal (20.04) specific host configurer implementation
+type FocalConfigurer struct {
+	Configurer
+}

--- a/pkg/configurer/ubuntu/ubuntu.go
+++ b/pkg/configurer/ubuntu/ubuntu.go
@@ -43,6 +43,15 @@ func resolveUbuntuConfigurer(h configurer.Host, os *common.OsRelease) interface{
 		return nil
 	}
 	switch os.Version {
+	case "20.04":
+		configurer := &FocalConfigurer{
+			Configurer: Configurer{
+				LinuxConfigurer: configurer.LinuxConfigurer{
+					Host: h,
+				},
+			},
+		}
+	return configurer
 	case "18.04":
 		configurer := &BionicConfigurer{
 			Configurer: Configurer{


### PR DESCRIPTION
- new ubuntu focal configurator
- ubuntu resolveUbuntuConfigurer() now recognizes 20.04 as focal

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>