### PR TITLE
Roll back the disabling of cleanup for MKE image list

### DIFF
--- a/pkg/product/mke/phase/pull_mke_images.go
+++ b/pkg/product/mke/phase/pull_mke_images.go
@@ -15,7 +15,6 @@ import (
 type PullMKEImages struct {
 	phase.Analytics
 	phase.BasicPhase
-	phase.CleanupDisabling
 }
 
 // Title for the phase
@@ -60,12 +59,7 @@ func (p *PullMKEImages) ListImages() ([]*docker.Image, error) {
 		}
 	}
 
-	runFlags := common.Flags{}
-	runFlags.Add("-v /var/run/docker.sock:/var/run/docker.sock")
-
-	if !p.CleanupDisabled() {
-		runFlags.Add("--rm")
-	}
+	runFlags := common.Flags{"--rm", "-v /var/run/docker.sock:/var/run/docker.sock"}
 
 	if manager.Configurer.SELinuxEnabled(manager) {
 		runFlags.Add("--security-opt label=disable")


### PR DESCRIPTION
When MKE bootstrapper is used for listing images; the container should always be removed even if cleanup is
disabled. Otherwise the container will stick around and prevent install from proceeding due to the existence
of another bootstrap container.

Signed-off-by: Vikram bir Singh <vsingh@mirantis.com>