### PR TITLE
Allow swarm updates immediately post swarm init

### DIFF
--- a/pkg/product/mke/api/mke_config.go
+++ b/pkg/product/mke/api/mke_config.go
@@ -13,23 +13,24 @@ import (
 
 // MKEConfig has all the bits needed to configure mke during installation
 type MKEConfig struct {
-	Version           string       `yaml:"version"`
-	ImageRepo         string       `yaml:"imageRepo,omitempty"`
-	AdminUsername     string       `yaml:"adminUsername,omitempty"`
-	AdminPassword     string       `yaml:"adminPassword,omitempty"`
-	InstallFlags      common.Flags `yaml:"installFlags,omitempty,flow"`
-	SwarmInstallFlags common.Flags `yaml:"swarmInstallFlags,omitempty,flow"`
-	UpgradeFlags      common.Flags `yaml:"upgradeFlags,omitempty,flow"`
-	ConfigFile        string       `yaml:"configFile,omitempty" validate:"omitempty,file"`
-	ConfigData        string       `yaml:"configData,omitempty"`
-	LicenseFilePath   string       `yaml:"licenseFilePath,omitempty" validate:"omitempty,file"`
-	CACertPath        string       `yaml:"caCertPath,omitempty" validate:"omitempty,file"`
-	CertPath          string       `yaml:"certPath,omitempty" validate:"omitempty,file"`
-	KeyPath           string       `yaml:"keyPath,omitempty" validate:"omitempty,file"`
-	CACertData        string       `yaml:"caCertData,omitempty"`
-	CertData          string       `yaml:"certData,omitempty"`
-	KeyData           string       `yaml:"keyData,omitempty"`
-	Cloud             *MKECloud    `yaml:"cloud,omitempty"`
+	Version             string       `yaml:"version"`
+	ImageRepo           string       `yaml:"imageRepo,omitempty"`
+	AdminUsername       string       `yaml:"adminUsername,omitempty"`
+	AdminPassword       string       `yaml:"adminPassword,omitempty"`
+	InstallFlags        common.Flags `yaml:"installFlags,omitempty,flow"`
+	SwarmInstallFlags   common.Flags `yaml:"swarmInstallFlags,omitempty,flow"`
+	SwarmUpdateCommands []string     `yaml:"swarmUpdateCommands,omitempty,flow"`
+	UpgradeFlags        common.Flags `yaml:"upgradeFlags,omitempty,flow"`
+	ConfigFile          string       `yaml:"configFile,omitempty" validate:"omitempty,file"`
+	ConfigData          string       `yaml:"configData,omitempty"`
+	LicenseFilePath     string       `yaml:"licenseFilePath,omitempty" validate:"omitempty,file"`
+	CACertPath          string       `yaml:"caCertPath,omitempty" validate:"omitempty,file"`
+	CertPath            string       `yaml:"certPath,omitempty" validate:"omitempty,file"`
+	KeyPath             string       `yaml:"keyPath,omitempty" validate:"omitempty,file"`
+	CACertData          string       `yaml:"caCertData,omitempty"`
+	CertData            string       `yaml:"certData,omitempty"`
+	KeyData             string       `yaml:"keyData,omitempty"`
+	Cloud               *MKECloud    `yaml:"cloud,omitempty"`
 
 	Metadata *MKEMetadata `yaml:"-"`
 }

--- a/pkg/product/mke/phase/init_swarm.go
+++ b/pkg/product/mke/phase/init_swarm.go
@@ -31,6 +31,17 @@ func (p *InitSwarm) Run() error {
 		if err != nil {
 			return fmt.Errorf("failed to initialize swarm: %s", output)
 		}
+
+		// Execute all swarm-post-init commands. These take care of
+		// things like setting cert-expiry which cannot be done at the
+		// time of swarm install.
+		for _, swarmCmd := range p.Config.Spec.MKE.SwarmUpdateCommands {
+			output, err := swarmLeader.ExecOutput(swarmLeader.Configurer.DockerCommandf("%s", swarmCmd))
+			if err != nil {
+				return fmt.Errorf("post swarm init command (%s) failed: %s", swarmCmd, output)
+			}
+		}
+
 		log.Infof("%s: swarm initialized successfully", swarmLeader)
 	} else {
 		log.Infof("%s: swarm already initialized", swarmLeader)


### PR DESCRIPTION
Some of the swarm configuration is only exposed after a successful `swarm init`. For example specifying
`--cert-expiry` with `swarm init` time is a no-op. One needs to update this value after a successful `swarm init` in two steps e.g.

1. `docker swarm init`
2. `docker swarm update cert-expiry 5h` [or `docker swarm ca --rotate --cert-expiry 5h`]

The changes here make it possible to do so.

Signed-off-by: Vikram bir Singh <vsingh@mirantis.com>