### PR TITLE
Use --enable-windows for MKE windows image listing

### DIFF
--- a/pkg/product/mke/phase/pull_mke_images.go
+++ b/pkg/product/mke/phase/pull_mke_images.go
@@ -60,7 +60,7 @@ func (p *PullMKEImages) Run() error {
 				return err
 			}
 
-			log.Debugf("%h: retagging images", h)
+			log.Debugf("%s: retagging images", h)
 			return docker.RetagAllToRepository(h, list, images[0].Repository)
 		})
 	}


### PR DESCRIPTION
The `Pull MKE Images` phase has been modified like so:

* Windows images are now listed using `--enable-windows`
* Those images will always be pulled to windows workers, never to managers.
* Linux images will be pulled to managers
* ..except when using a custom image repository, in that case, all linux images are pulled to all linux hosts and windows images are pulled to windows hosts. After pulling is done, the images are retagged.

