### PR TITLE
Revert set MSRVersion constant to 2.9.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,36 +181,32 @@ pipeline {
             }
           }
           stages {
-            stage("Install MKE3.3.3 MSR2.8 MCR19.03.8") {
+            stage("Install MKE3.3.3 MSR2.7 MCR19.03.8") {
               environment {
                 LINUX_IMAGE = "quay.io/footloose/ubuntu18.04"
                 FOOTLOOSE_TEMPLATE = "footloose-msr.yaml.tpl"
                 LAUNCHPAD_CONFIG = "launchpad-msr.yaml"
-                MKE_VERSION = "3.3.6"
+                MKE_VERSION = "3.3.3"
                 MKE_IMAGE_REPO = "docker.io/mirantis"
-                MSR_VERSION = "2.8.5"
+                MSR_VERSION = "2.7.8"
                 MSR_IMAGE_REPO = "docker.io/mirantis"
                 MCR_VERSION = "19.03.8"
-                MCR_CHANNEL = "stable"
-                MCR_REPO_URL = "https://repos.mirantis.com"
                 PRESERVE_CLUSTER = "true"
               }
               steps {
                 sh "make smoke-test"
               }
             }
-            stage("Upgrade MKE3.4.0-tp2 MSR2.9.0-tp3 ENG20.10.0-rc2 from private repos") {
+            stage("Upgrade MKE3.3.5-beta MSR2.8.5-beta ENG19.03.13 from private repos") {
               environment {
                 LINUX_IMAGE = "quay.io/footloose/ubuntu18.04"
                 FOOTLOOSE_TEMPLATE = "footloose-msr.yaml.tpl"
                 LAUNCHPAD_CONFIG = "launchpad-msr-beta.yaml"
-                MKE_VERSION = "3.4.0-tp2"
+                MKE_VERSION = "3.3.5-d1da376"
                 MKE_IMAGE_REPO = "docker.io/mirantiseng"
                 MSR_IMAGE_REPO = "docker.io/mirantiseng"
-                MSR_VERSION = "2.9.0-tp3"
-                MCR_VERSION = "20.10.0-rc2"
-                MCR_CHANNEL = "test"
-                MCR_REPO_URL = "https://repos-stage.mirantis.com"
+                MSR_VERSION = "2.8.5-rc1"
+                MCR_VERSION = "19.03.13"
                 REUSE_CLUSTER = "true"
                 PRESERVE_CLUSTER = "true"
               }

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -8,7 +8,7 @@ const (
 	// MKEVersion is the default MKE version to use
 	MKEVersion = "3.3.5"
 	// MSRVersion is the default MSR version to use
-	MSRVersion = "2.9.0"
+	MSRVersion = "2.8.5"
 	// MCRVersion is the default engine version
 	MCRVersion = "19.03.14"
 	// MCRChannel is the default engine channel

--- a/test/launchpad-msr-beta.yaml
+++ b/test/launchpad-msr-beta.yaml
@@ -50,8 +50,6 @@ spec:
       - --force-minimums
       - --force-recent-backup
   mcr:
-    repoURL: $MCR_REPO_URL
-    channel: $MCR_CHANNEL
     version: $MCR_VERSION
   msr:
     version: $MSR_VERSION


### PR DESCRIPTION
* This patch reverts #291 but leaves the typo fix.
* Will reapply this patch when v2.9.0 ships at a later date.

Signed-off-by: Kyle Squizzato <ksquizzato@mirantis.com>