### PR TITLE
Use "ip addr show" instead of "hostname --all-ip-addresses" on SLES

### DIFF
--- a/pkg/configurer/sles/sles.go
+++ b/pkg/configurer/sles/sles.go
@@ -20,7 +20,7 @@ type Configurer struct {
 
 // InstallMKEBasePackages installs the needed base packages on Ubuntu
 func (c Configurer) InstallMKEBasePackages(h os.Host) error {
-	return c.InstallPackage(h, "curl", "socat", "hostname")
+	return c.InstallPackage(h, "curl", "socat")
 }
 
 // UninstallMCR uninstalls docker-ee engine


### PR DESCRIPTION
Appears the version installed by default does not have the `--all-ip-addresses` option.

This makes SLES use `ip addr show | grep 'inet ' | awk '{print $2}' | cut -d/ -f1` instead.
