### PR TITLE
Add config spec.msr certificate fields

### DIFF
--- a/pkg/product/mke/api/msr_config.go
+++ b/pkg/product/mke/api/msr_config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Mirantis/mcc/pkg/constant"
 	common "github.com/Mirantis/mcc/pkg/product/common/api"
+	"github.com/Mirantis/mcc/pkg/util"
 	"github.com/creasty/defaults"
 	"github.com/hashicorp/go-version"
 )
@@ -17,6 +18,12 @@ type MSRConfig struct {
 	InstallFlags common.Flags `yaml:"installFlags,flow,omitempty"`
 	UpgradeFlags common.Flags `yaml:"upgradeFlags,flow,omitempty"`
 	ReplicaIDs   string       `yaml:"replicaIDs,omitempty"  default:"random"`
+	CACertPath   string       `yaml:"caCertPath,omitempty" validate:"omitempty,file"`
+	CertPath     string       `yaml:"certPath,omitempty" validate:"omitempty,file"`
+	KeyPath      string       `yaml:"keyPath,omitempty" validate:"omitempty,file"`
+	CACertData   string       `yaml:"caCertData,omitempty"`
+	CertData     string       `yaml:"certData,omitempty"`
+	KeyData      string       `yaml:"keyData,omitempty"`
 }
 
 // UnmarshalYAML sets in some sane defaults when unmarshaling the data from yaml
@@ -31,6 +38,30 @@ func (c *MSRConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if _, err := version.NewVersion(c.Version); err != nil {
 			return fmt.Errorf("invalid version: %s: %s", c.Version, err.Error())
 		}
+	}
+
+	if c.CACertPath != "" {
+		caCertData, err := util.LoadExternalFile(c.CACertPath)
+		if err != nil {
+			return err
+		}
+		c.CACertData = string(caCertData)
+	}
+
+	if c.CertPath != "" {
+		certData, err := util.LoadExternalFile(c.CertPath)
+		if err != nil {
+			return err
+		}
+		c.CertData = string(certData)
+	}
+
+	if c.KeyPath != "" {
+		keyData, err := util.LoadExternalFile(c.KeyPath)
+		if err != nil {
+			return err
+		}
+		c.KeyData = string(keyData)
 	}
 
 	return defaults.Set(c)

--- a/pkg/product/mke/phase/install_msr.go
+++ b/pkg/product/mke/phase/install_msr.go
@@ -68,6 +68,22 @@ func (p *InstallMSR) Run() error {
 
 	installFlags.Merge(mkeFlags)
 
+	if p.Config.Spec.MSR.CACertData != "" {
+		installFlags.AddOrReplace(fmt.Sprintf("--dtr-ca %s", p.Config.Spec.MSR.CACertData))
+	}
+
+	if p.Config.Spec.MSR.CertData != "" {
+		installFlags.AddOrReplace(fmt.Sprintf("--dtr-cert %s", p.Config.Spec.MSR.CertData))
+	}
+
+	if p.Config.Spec.MSR.KeyData != "" {
+		installFlags.AddOrReplace(fmt.Sprintf("--dtr-key %s", p.Config.Spec.MSR.KeyData))
+	}
+
+	if p.Config.Spec.MKE.CACertData != "" {
+		installFlags.AddOrReplace(fmt.Sprintf("--ucp-ca %s", p.Config.Spec.MKE.CACertData))
+	}
+
 	if h.MSRMetadata.ReplicaID != "" {
 		log.Infof("%s: installing MSR with replica id %s", h, h.MSRMetadata.ReplicaID)
 		installFlags.AddOrReplace(fmt.Sprintf("--replica-id %s", h.MSRMetadata.ReplicaID))
@@ -76,7 +92,7 @@ func (p *InstallMSR) Run() error {
 	}
 
 	installCmd := h.Configurer.DockerCommandf("run %s %s install %s", runFlags.Join(), image, installFlags.Join())
-	err = h.Exec(installCmd, exec.StreamOutput(), exec.RedactString(installFlags.GetValue("--ucp-username"), installFlags.GetValue("--ucp-password")))
+	err = h.Exec(installCmd, exec.StreamOutput(), exec.RedactString(installFlags.GetValue("--ucp-username"), installFlags.GetValue("--ucp-password"), p.Config.Spec.MSR.CACertData, p.Config.Spec.MSR.CertData, p.Config.Spec.MSR.KeyData, p.Config.Spec.MKE.CACertData))
 	if err != nil {
 		return fmt.Errorf("%s: failed to run MSR installer: %s", h, err.Error())
 	}


### PR DESCRIPTION
* Adds `spec.msr` fields: `CACertPath`, `CertPath`, `KeyPath` (or to embed into yaml: `CACertData`,  `CertData`, `KeyData`).
* If MKE CA has been defined, MSR `--ucp-ca` will be applied (during MSR install and upgrade)

