### PR TITLE
Fix MKE bootstrap image name

### DIFF
--- a/pkg/mke/mke.go
+++ b/pkg/mke/mke.go
@@ -35,8 +35,6 @@ type Credentials struct {
 }
 
 // CollectFacts gathers the current status of installed mke setup
-// Currently we only need to know the existing version and whether mke is installed or not.
-// In future we probably need more.
 func CollectFacts(swarmLeader *api.Host, mkeMeta *api.MKEMetadata) error {
 	output, err := swarmLeader.ExecOutput(swarmLeader.Configurer.DockerCommandf(`inspect --format '{{.Config.Image}}' ucp-proxy`))
 	if err != nil {


### PR DESCRIPTION
It's a bit of a mystery to me why this search & replace error present since 2020-11-18 does not make everything fail. The `InstalledBootstrapImage` is used in several stages during the process.
