### PR TITLE
Fix SSH pubkey auth when agent exist + allow 1-char usernames

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/google/go-cmp v0.5.1 // indirect
 	github.com/hashicorp/go-version v1.2.0
 	github.com/k0sproject/dig v0.1.0
-	github.com/k0sproject/rig v0.3.21
+	github.com/k0sproject/rig v0.3.22
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/k0sproject/dig v0.1.0 h1:EpdMdt7V5eRvZ1h7hX7AeL9cXbRTXt91oZO1pQBDTSU=
 github.com/k0sproject/dig v0.1.0/go.mod h1:rBcqaQlJpcKdt2x/OE/lPvhGU50u/e95CSm5g/r4s78=
-github.com/k0sproject/rig v0.3.21 h1:kUFYSTULHbXp8HgQHWJZGtmdj+AtY/lTT1ZH54Q/wMk=
-github.com/k0sproject/rig v0.3.21/go.mod h1:6BgqiLQMw5SCMrysZ42ORzyXd3NOyr9KDEa2UGYphdY=
+github.com/k0sproject/rig v0.3.22 h1:QlZg5/DqBVmk+Mt6fnHiBG4elMJPI1i7dAxTteSmjXo=
+github.com/k0sproject/rig v0.3.22/go.mod h1:6BgqiLQMw5SCMrysZ42ORzyXd3NOyr9KDEa2UGYphdY=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
Updates rig to 0.3.22 to bring:

* Allow usernames shorter than 3 characters ([rig/#31](https://github.com/k0sproject/rig/pull/31))
* Fix SSH login when both keyPath and ssh-agent defined ([rig/#30](https://github.com/k0sproject/rig/pull/30))
* Improve init system detection and fix nil panic when failing to detect one ([rig/#32](https://github.com/k0sproject/rig/pull/32))
