### PR TITLE
Re-tag MKE images to docker.io/mirantis

### DIFF
--- a/pkg/product/mke/phase/pull_mke_images.go
+++ b/pkg/product/mke/phase/pull_mke_images.go
@@ -61,7 +61,7 @@ func (p *PullMKEImages) Run() error {
 			}
 
 			log.Debugf("%s: retagging images", h)
-			return docker.RetagAllToRepository(h, list, images[0].Repository)
+			return docker.RetagAllToRepository(h, list, "mirantis")
 		})
 	}
 


### PR DESCRIPTION
Currently, images are retagged to have the same registry and repo as
the bootstrapper image, but this doesn't work for MKE versions above
3.3.7.