### PR TITLE
Fix MCR upgrade when MSR not installed yet

### DIFF
--- a/pkg/product/mke/phase/upgrade_mcr.go
+++ b/pkg/product/mke/phase/upgrade_mcr.go
@@ -94,16 +94,18 @@ func (p *UpgradeMCR) upgradeMCRs() error {
 
 	// Upgrade MSR hosts individually
 	for _, h := range msrs {
-		if err := msr.WaitMSRNodeReady(h, port); err != nil {
-			return err
+		if h.MSRMetadata.Installed {
+			if err := msr.WaitMSRNodeReady(h, port); err != nil {
+				return err
+			}
 		}
 		if err := p.upgradeMCR(h); err != nil {
 			return err
 		}
-		if err := msr.WaitMSRNodeReady(h, port); err != nil {
-			return err
-		}
 		if h.MSRMetadata.Installed {
+			if err := msr.WaitMSRNodeReady(h, port); err != nil {
+				return err
+			}
 			err := retry.Do(
 				func() error {
 					if _, err := msr.CollectFacts(h); err != nil {


### PR DESCRIPTION
An mcr upgrade would fail on a host that has the `msr` role but where msr has not yet been installed, as launchpad would try to check that msr is healthy before proceeding to upgrade mcr.
