### PR TITLE
PRODENG-1597 make productFromYAML public

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,7 +39,7 @@ func ProductFromFile(path string) (product.Product, error) {
 	if err != nil {
 		return nil, err
 	}
-	return productFromYAML(data)
+	return ProductFromYAML(data)
 }
 
 // ProductFromYAML returns a Product from YAML bytes, or an error


### PR DESCRIPTION
- previously private method now public
- integrations can now create Product objects from YAML strings instead
  having to write yaml to a file.

Signed-off-by: James Nesbitt <james.r.nesbitt@gmail.com>