### PR TITLE
Don't reconfigure and restart MCR if daemon.json wasn't changed

### DIFF
--- a/pkg/product/mke/api/host.go
+++ b/pkg/product/mke/api/host.go
@@ -28,6 +28,7 @@ type HostMetadata struct {
 	MCRRestartRequired bool
 	ImagesToUpload     []string
 	TotalImageBytes    uint64
+	DaemonJSONChanged  bool
 }
 
 // MSRMetadata is metadata needed by MSR for configuration and is gathered at
@@ -239,14 +240,7 @@ func (h *Host) ConfigureMCR() error {
 		daemonJSON := string(daemonJSONData)
 
 		cfg := h.Configurer.MCRConfigPath()
-		oldConfig := ""
 		if h.Configurer.FileExist(h, cfg) {
-			f, err := h.Configurer.ReadFile(h, cfg)
-			if err != nil {
-				return err
-			}
-			oldConfig = f
-
 			log.Debugf("deleting %s", cfg)
 			if err := h.Configurer.DeleteFile(h, cfg); err != nil {
 				return err
@@ -257,7 +251,7 @@ func (h *Host) ConfigureMCR() error {
 		if err := h.Configurer.WriteFile(h, cfg, daemonJSON, "0700"); err != nil {
 			return err
 		}
-		if h.Metadata.MCRVersion != "" && oldConfig != daemonJSON {
+		if h.Metadata.MCRVersion != "" && h.Metadata.DaemonJSONChanged {
 			h.Metadata.MCRRestartRequired = true
 		}
 	}

--- a/pkg/product/mke/phase/configure_mcr.go
+++ b/pkg/product/mke/phase/configure_mcr.go
@@ -15,7 +15,7 @@ type ConfigureMCR struct {
 
 // HostFilterFunc returns true for hosts that need their engine to be restarted
 func (p *ConfigureMCR) HostFilterFunc(h *api.Host) bool {
-	return len(h.DaemonConfig) > 0
+	return len(h.DaemonConfig) > 0 && h.Metadata.DaemonJSONChanged
 }
 
 // Prepare collects the hosts

--- a/pkg/product/mke/phase/validate_facts.go
+++ b/pkg/product/mke/phase/validate_facts.go
@@ -32,6 +32,9 @@ func (p *ValidateFacts) Run() error {
 
 	p.Config.Spec.Hosts.Each(func(h *api.Host) error {
 		if h.Configurer != nil && h.Configurer.SELinuxEnabled(h) {
+			if se, ok := h.DaemonConfig["selinux-enabled"].(bool); !ok || !se {
+				h.Metadata.DaemonJSONChanged = true
+			}
 			h.DaemonConfig["selinux-enabled"] = true
 			log.Infof("%s: adding 'selinux-enabled=true' to host container runtime config", h)
 		}


### PR DESCRIPTION
Prevents launchpad from rewriting daemon.json and doing an MCR restart when there are no changes to daemon.json.
