### PR TITLE
Don't restart MCR if daemon.json wasn't changed

### DIFF
--- a/pkg/product/mke/api/host.go
+++ b/pkg/product/mke/api/host.go
@@ -264,9 +264,8 @@ func (h *Host) ConfigureMCR() error {
 				h.Metadata.MCRRestartRequired = true
 			} else {
 				oldJSON := make(dig.Mapping)
-				if err := json.Unmarshal([]byte(oldConfig), &oldJSON); err == nil {
-					h.Metadata.MCRRestartRequired = !reflect.DeepEqual(oldJSON, h.DaemonConfig)
-				}
+				err := json.Unmarshal([]byte(oldConfig), &oldJSON)
+				h.Metadata.MCRRestartRequired = err != nil || !reflect.DeepEqual(oldJSON, h.DaemonConfig)
 			}
 		}
 	}


### PR DESCRIPTION
Improves the change detection logic from plain ascii equality comparison to reflect.DeepEqual to ignore any cosmetic formatting / ordering changes.
