### PR TITLE
Change apply --concurrency to be an integer

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -27,8 +27,8 @@ func NewApplyCommand() *cli.Command {
 			redactFlag,
 			&cli.IntFlag{
 				Name:  "concurrency",
-				Usage: "Worker upgrade concurrency (percentage)",
-				Value: 10,
+				Usage: "Worker upgrade concurrency (number of simultaneous nodes)",
+				Value: 5,
 			},
 			&cli.BoolFlag{
 				Name:    "force",
@@ -46,8 +46,8 @@ func NewApplyCommand() *cli.Command {
 		Before: actions(initLogger, startUpgradeCheck, initAnalytics, checkLicense, initExec),
 		After:  actions(closeAnalytics, upgradeCheckResult),
 		Action: func(ctx *cli.Context) (err error) {
-			if ctx.Int("concurrency") < 1 || ctx.Int("concurrency") > 100 {
-				return fmt.Errorf("invalid --concurrency %d (must be 1..100)", ctx.Int("concurrency"))
+			if ctx.Int("concurrency") < 1 {
+				return fmt.Errorf("invalid --concurrency %d (must be 1 or more)", ctx.Int("concurrency"))
 			}
 
 			var logFile *os.File

--- a/pkg/product/mke/phase/upgrade_mcr.go
+++ b/pkg/product/mke/phase/upgrade_mcr.go
@@ -2,7 +2,6 @@ package phase
 
 import (
 	"fmt"
-	"math"
 	"strconv"
 	"sync"
 	"time"
@@ -125,13 +124,8 @@ func (p *UpgradeMCR) upgradeMCRs() error {
 		}
 	}
 
-	// Upgrade worker hosts parallelly in 10% chunks
-	concurrentUpgrades := int(math.Floor(float64(len(workers)) * (float64(p.Concurrency) / 100.0)))
-	if concurrentUpgrades == 0 {
-		concurrentUpgrades = 1
-	}
-	log.Debugf("concurrently upgrading workers in batches of %d", concurrentUpgrades)
-	wp := workerpool.New(concurrentUpgrades)
+	log.Debugf("concurrently upgrading workers in batches of %d", p.Concurrency)
+	wp := workerpool.New(p.Concurrency)
 	mu := sync.Mutex{}
 	installErrors := &phase.Error{}
 	for _, w := range workers {


### PR DESCRIPTION
Using a percentage makes very little sense as the number is related to the count of eligible nodes for an upgrade.

Currently:

- If you have 100 workers and set concurrency to 10, when all clusters need an upgrade, then 10 at a time is upgraded.
- If only 10 workers need to be upgraded, it will be done one at a time.

This PR changes the --concurrency param to be a regular number, not a percentage. The default value is 5.

TODO: consider considering 0 as "unlimited"

An alternative would be to always calculate the concurrency from the total number of nodes. But even that is pretty pointless. User does not want to do maths.
