### PR TITLE
Fix bash completion script

### DIFF
--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -34,7 +34,7 @@ _launchpad_bash_autocomplete() {
   fi
 }
 
-complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete %s
+complete -o bashdefault -o default -o nospace -F _launchpad_bash_autocomplete %s
 `, prog())
 }
 


### PR DESCRIPTION
Looks like probably a copy/paste error - the name should match the function defined just above this.

**Testing**

I did not check out and build the project, but this name change fixed a completion script I was using generated by launchpad v1.5.2.