### PR TITLE
PRODENG-2480 Launchpad reset now cleans the lingering MCR files

### DIFF
--- a/pkg/configurer/common.go
+++ b/pkg/configurer/common.go
@@ -1,0 +1,50 @@
+package configurer
+
+import (
+	"encoding/json"
+	"fmt"
+
+	common "github.com/Mirantis/mcc/pkg/product/common/api"
+	"github.com/k0sproject/rig/log"
+	"github.com/k0sproject/rig/os"
+)
+
+type DockerConfigurer struct{}
+
+// GetDockerInfo gets docker info from the host
+func (c DockerConfigurer) GetDockerInfo(h os.Host, hostKind string) (common.DockerInfo, error) {
+	command := "docker info --format \"{{json . }}\""
+	log.Infof("%s attempting to execute `docker info`", h)
+	info, err := h.ExecOutput(command)
+
+	if err != nil && hostKind != "windows" {
+		log.Infof("%s attempting to execute `docker info` with sudo", h)
+		info, err = h.ExecOutput(fmt.Sprintf("sudo %s", command))
+		if err != nil {
+			return common.DockerInfo{}, err
+		}
+	}
+
+	var dockerInfo common.DockerInfo
+	err = json.Unmarshal([]byte(info), &dockerInfo)
+	if err != nil {
+		log.Infof("%s no `docker info` found", h)
+		return common.DockerInfo{}, err
+	}
+
+	return dockerInfo, nil
+}
+
+// GetDockerDaemonConfig parses docker daemon json string and populate DockerDaemonConfig struct
+func (c DockerConfigurer) GetDockerDaemonConfig(dockerDaemon string) (common.DockerDaemonConfig, error) {
+	if dockerDaemon != "" {
+		return common.DockerDaemonConfig{}, fmt.Errorf("the docker daemon config is empty")
+	}
+
+	var config common.DockerDaemonConfig
+	if err := json.Unmarshal([]byte(dockerDaemon), &config); err != nil {
+		return common.DockerDaemonConfig{}, fmt.Errorf("failed to unmarshal json content: %w", err)
+	}
+
+	return config, nil
+}

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -21,4 +21,14 @@ const (
 	ManagedLabelCmd = "node update --label-add com.mirantis.launchpad.managed=true"
 	// ManagedMSRLabelCmd marks a MSR node as being managed by launchpad.
 	ManagedMSRLabelCmd = "node update --label-add com.mirantis.launchpad.managed.dtr=true"
+	// LinuxDefaultDockerRoot defines the default docker root.
+	LinuxDefaultDockerRoot = "/var/lib/docker"
+	// LinuxDefaultDockerExecRoot defines the default docker exec root.
+	LinuxDefaultDockerExecRoot = "/var/run/docker"
+	// LinuxDefaultDockerDaemonPath defines the default docker daemon path.
+	LinuxDefaultDockerDaemonPath = "/etc/docker/daemon.json"
+	// LinuxDefaultRootlessDockerDaemonPath defines the default rootless docker daemon path.
+	LinuxDefaultRootlessDockerDaemonPath = "~/.config/docker/daemon.json"
+	// WindowsDefaultDockerRoot defines the default windows docker root.
+	WindowsDefaultDockerRoot = "C:\\ProgramData\\Docker"
 )

--- a/pkg/product/common/api/mcr_config.go
+++ b/pkg/product/common/api/mcr_config.go
@@ -4,6 +4,19 @@ import (
 	"github.com/Mirantis/mcc/pkg/constant"
 )
 
+type DockerInfo struct {
+	ServerVersion string `json:"ServerVersion"`
+	APIVersion    string `json:"APIVersion"`
+	OS            string `json:"OperatingSystem"`
+	KernelVersion string `json:"KernelVersion"`
+	DockerRootDir string `json:"DockerRootDir"`
+}
+
+type DockerDaemonConfig struct {
+	ExecRoot string `json:"exec-root"`
+	Root     string `json:"root-data"`
+}
+
 // MCRConfig holds the Mirantis Container Runtime installation specific options.
 type MCRConfig struct {
 	Version           string `yaml:"version"`
@@ -11,6 +24,7 @@ type MCRConfig struct {
 	InstallURLLinux   string `yaml:"installURLLinux,omitempty"`
 	InstallURLWindows string `yaml:"installURLWindows,omitempty"`
 	Channel           string `yaml:"channel,omitempty"`
+	Prune             bool   `yaml:"prune,omitempty"`
 }
 
 // UnmarshalYAML puts in sane defaults when unmarshaling from yaml.

--- a/pkg/product/mke/phase/uninstall_mcr.go
+++ b/pkg/product/mke/phase/uninstall_mcr.go
@@ -24,13 +24,9 @@ func (p *UninstallMCR) Run() error {
 }
 
 func (p *UninstallMCR) uninstallMCR(h *api.Host, c *api.ClusterConfig) error {
-	err := h.Exec(h.Configurer.DockerCommandf("info"))
-	if err != nil {
-		log.Infof("%s: container runtime not installed, skipping", h)
-		return nil //nolint:nilerr
-	}
 	log.Infof("%s: uninstalling container runtime", h)
-	err = h.Configurer.UninstallMCR(h, h.Metadata.MCRInstallScript, c.Spec.MCR)
+
+	err := h.Configurer.UninstallMCR(h, h.Metadata.MCRInstallScript, c.Spec.MCR)
 	if err == nil {
 		log.Infof("%s: mirantis container runtime uninstalled", h)
 	}


### PR DESCRIPTION
- Created CleanupLingerMCR files function for both Linux and Windows Configurer
- We can do `launchpad reset` even when docker is malformed or not correctly installed
- Created a common.go file which contains Common Configurer logic

https://mirantis.jira.com/browse/PRODENG-2480