### PR TITLE
PRODENG-2449 install MKE cert on upgrade

### DIFF
--- a/pkg/product/mke/phase/install_mke.go
+++ b/pkg/product/mke/phase/install_mke.go
@@ -48,8 +48,7 @@ func (p *InstallMKE) Run() (err error) {
 	installFlags := p.Config.Spec.MKE.InstallFlags
 
 	if p.Config.Spec.MKE.CACertData != "" && p.Config.Spec.MKE.CertData != "" && p.Config.Spec.MKE.KeyData != "" {
-		err := p.installCertificates(p.Config)
-		if err != nil {
+		if err := installMKECertificates(p.Config); err != nil {
 			return err
 		}
 		installFlags.AddUnlessExist("--external-server-cert")
@@ -138,8 +137,8 @@ func (p *InstallMKE) Run() (err error) {
 	return nil
 }
 
-// installCertificates installs user supplied MKE certificates.
-func (p *InstallMKE) installCertificates(config *api.ClusterConfig) error {
+// installMKECertificates installs user supplied MKE certificates.
+func installMKECertificates(config *api.ClusterConfig) error {
 	log.Infof("Installing MKE certificates")
 	managers := config.Spec.Managers()
 	err := managers.ParallelEach(func(h *api.Host) error {

--- a/pkg/product/mke/phase/upgrade_mke.go
+++ b/pkg/product/mke/phase/upgrade_mke.go
@@ -35,6 +35,13 @@ func (p *UpgradeMKE) Run() error {
 		return nil
 	}
 
+	if p.Config.Spec.MKE.CACertData != "" && p.Config.Spec.MKE.CertData != "" && p.Config.Spec.MKE.KeyData != "" {
+		log.Info("Installing MKE UI certificates on upgrade (only works if install was run with --external-server-cert.)")
+		if err := installMKECertificates(p.Config); err != nil {
+			return err
+		}
+	}
+
 	swarmClusterID := swarm.ClusterID(swarmLeader)
 	runFlags := common.Flags{"-i", "-v /var/run/docker.sock:/var/run/docker.sock"}
 	if !p.CleanupDisabled() {


### PR DESCRIPTION
- install_mke phase method for installing certs turned into a function
- upgrade_mke phase now also runs the install cert function
- include a warning on upgrade that install needed to use custom certs already.