### PR TITLE
PRODENG-2528 allow force mcr upgrade

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -44,6 +44,12 @@ func NewApplyCommand() *cli.Command {
 				Value:  false,
 				Hidden: true,
 			},
+			&cli.BoolFlag{
+				Name:   "force-upgrade",
+				Usage:  "force upgrade to run on compatible components, even if it doesn't look necessary",
+				Value:  false,
+				Hidden: true,
+			},
 		}...),
 		Before: actions(initLogger, startUpgradeCheck, initAnalytics, checkLicense, initExec),
 		After:  actions(closeAnalytics, upgradeCheckResult),
@@ -79,7 +85,7 @@ func NewApplyCommand() *cli.Command {
 				fmt.Fprintf(os.Stdout, "   Mirantis Launchpad (c) 2022 Mirantis, Inc.                          %s\n\n", version.Version)
 			}
 
-			err = product.Apply(ctx.Bool("disable-cleanup"), ctx.Bool("force"), ctx.Int("concurrency"))
+			err = product.Apply(ctx.Bool("disable-cleanup"), ctx.Bool("force"), ctx.Int("concurrency"), ctx.Bool("force-upgrade"))
 			if err != nil {
 				analytics.TrackEvent("Cluster Apply Failed", nil)
 				return fmt.Errorf("failed to apply cluster: %w", err)

--- a/pkg/product/common/api/mcr_config.go
+++ b/pkg/product/common/api/mcr_config.go
@@ -25,6 +25,7 @@ type MCRConfig struct {
 	InstallURLWindows string `yaml:"installURLWindows,omitempty"`
 	Channel           string `yaml:"channel,omitempty"`
 	Prune             bool   `yaml:"prune,omitempty"`
+	ForceUpgrade      bool   `yaml:"forceUpgrade,omitempty"`
 }
 
 // UnmarshalYAML puts in sane defaults when unmarshaling from yaml.

--- a/pkg/product/mke/apply.go
+++ b/pkg/product/mke/apply.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Apply - installs Docker Enterprise (MKE, MSR, MCR) on the hosts that are defined in the config.
-func (p *MKE) Apply(disableCleanup, force bool, concurrency int) error {
+func (p *MKE) Apply(disableCleanup, force bool, concurrency int, forceUpgrade bool) error {
 	phaseManager := phase.NewManager(&p.ClusterConfig)
 	phaseManager.SkipCleanup = disableCleanup
 
@@ -30,7 +30,7 @@ func (p *MKE) Apply(disableCleanup, force bool, concurrency int) error {
 		// begin mcr/mke phases
 		&mke.ConfigureMCR{},
 		&mke.InstallMCR{},
-		&mke.UpgradeMCR{Concurrency: concurrency},
+		&mke.UpgradeMCR{Concurrency: concurrency, ForceUpgrade: forceUpgrade},
 		&mke.RestartMCR{},
 		&mke.LoadImages{},
 		&mke.AuthenticateDocker{},

--- a/pkg/product/mke/phase/upgrade_mcr.go
+++ b/pkg/product/mke/phase/upgrade_mcr.go
@@ -19,12 +19,21 @@ import (
 type UpgradeMCR struct {
 	phase.Analytics
 	phase.HostSelectPhase
-	Concurrency int
+
+	Concurrency  int
+	ForceUpgrade bool
 }
 
 // HostFilterFunc returns true for hosts that do not have engine installed.
 func (p *UpgradeMCR) HostFilterFunc(h *api.Host) bool {
-	return h.Metadata.MCRVersion != p.Config.Spec.MCR.Version
+	if h.Metadata.MCRVersion != p.Config.Spec.MCR.Version {
+		return true
+	}
+	if p.ForceUpgrade {
+		log.Warnf("%s: MCR version is already %s but attempting an upgrade anyway because --force-upgrade was given", h, h.Metadata.MCRVersion)
+		return true
+	}
+	return false
 }
 
 // Prepare collects the hosts.

--- a/pkg/product/product.go
+++ b/pkg/product/product.go
@@ -2,7 +2,7 @@ package product
 
 // Product is an interface that represents a product that launchpad can manage.
 type Product interface {
-	Apply(disableCleanup, force bool, concurrency int) error
+	Apply(disableCleanup, force bool, concurrency int, forceUpgrade bool) error
 	Reset() error
 	Describe(reportName string) error
 	ClientConfig() error


### PR DESCRIPTION
This allows a command argument which will force the MCR upgrade phase to select all hosts, even if they look like they already match the requested version.

- product.Product.Apply now accepts "force upgrade compatible products" flag
- MKE product uses the flag in the upgrade MCR phase
- if MCR upgrade phase recieves true for the flag, then all hosts get upgraded
- cmd.Apply recieves a cli arg, and passes it as the "force upgrade" Product flag

https://mirantis.jira.com/browse/PRODENG-2528