### PR TITLE
PRODENG-2528 apply --force-upgrade doesn't double install

### DIFF
--- a/pkg/product/mke/api/host.go
+++ b/pkg/product/mke/api/host.go
@@ -29,6 +29,7 @@ type HostMetadata struct {
 	MCRRestartRequired bool
 	ImagesToUpload     []string
 	TotalImageBytes    uint64
+	MCRInstalled       bool
 }
 
 // MSRMetadata is metadata needed by MSR for configuration and is gathered at

--- a/pkg/product/mke/phase/install_mcr.go
+++ b/pkg/product/mke/phase/install_mcr.go
@@ -102,5 +102,6 @@ func (p *InstallMCR) installMCR(h *api.Host) error {
 	log.Infof("%s: mirantis container runtime version %s installed", h, p.Config.Spec.MCR.Version)
 	h.Metadata.MCRVersion = p.Config.Spec.MCR.Version
 	h.Metadata.MCRRestartRequired = false
+	h.Metadata.MCRInstalled = true
 	return nil
 }

--- a/pkg/product/mke/phase/upgrade_mcr.go
+++ b/pkg/product/mke/phase/upgrade_mcr.go
@@ -29,7 +29,7 @@ func (p *UpgradeMCR) HostFilterFunc(h *api.Host) bool {
 	if h.Metadata.MCRVersion != p.Config.Spec.MCR.Version {
 		return true
 	}
-	if p.ForceUpgrade {
+	if p.ForceUpgrade && !h.Metadata.MCRInstalled {
 		log.Warnf("%s: MCR version is already %s but attempting an upgrade anyway because --force-upgrade was given", h, h.Metadata.MCRVersion)
 		return true
 	}


### PR DESCRIPTION
- track if a host has been installed
- use the install tracking information for prevent upgrading on an installed host