### PR TITLE
PRODENG-2529 disable cgo in build

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,6 +5,7 @@ RUN apt-get update
 WORKDIR /go/src/github.com/Mirantis/mcc
 
 ENV GO111MODULE=on
+ENV CGO_ENABLED=0
 
 ADD go.mod go.sum ./
 


### PR DESCRIPTION
- fixes glibc version issues on newer platforms
- cherry-pick of the hotfix change