### PR TITLE
PRDOENG-2530 Added Windows binary signing in gh release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,5 +12,10 @@ jobs:
               uses: actions/checkout@v2
             - name: Run release script
               env:
-                TAG_NAME: ${{  github.ref_name }}
-              run: make release
+                TAG_NAME: ${{ github.ref_name }}
+                SM_API_KEY: ${{ secrets.SM_API_KEY }}
+                SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+              run: |
+                echo "${{ secrets.SM_CLIENT_PKC12_CERT }}" > secret.txt
+                echo "SM_CLIENT_CERT_FILE=$(pwd)/secret.txt" >> $GITHUB_ENV
+                make release


### PR DESCRIPTION
* Added the needed environment variables for digicert to sign the mcc Windows binary

https://mirantis.jira.com/browse/PRODENG-2530