### PR TITLE
PRODENG-2539 Re-enable config validation and validation testing

### DIFF
--- a/pkg/product/mke/api/cluster_spec.go
+++ b/pkg/product/mke/api/cluster_spec.go
@@ -23,7 +23,7 @@ type Cluster struct {
 
 // ClusterSpec defines cluster spec.
 type ClusterSpec struct {
-	Hosts   Hosts            `yaml:"hosts" validate:"required,min=1"`
+	Hosts   Hosts            `yaml:"hosts" validate:"required,min=1,dive"`
 	MKE     MKEConfig        `yaml:"mke,omitempty"`
 	MSR     *MSRConfig       `yaml:"msr,omitempty"`
 	MCR     common.MCRConfig `yaml:"mcr,omitempty"`

--- a/pkg/product/mke/api/cluster_test.go
+++ b/pkg/product/mke/api/cluster_test.go
@@ -95,7 +95,6 @@ spec:
 }
 
 func TestHostAddressValidationWithInvalidIP(t *testing.T) {
-	t.Skip("TODO: Validation is currently broken")
 	data := `
 apiVersion: launchpad.mirantis.com/mke/v1.4
 kind: mke
@@ -104,7 +103,8 @@ spec:
 	  version: 3.3.7
   hosts:
   - ssh:
-      address: "512.1.2.3"
+      address: "512.1.2.3.@"
+    role: manager
 `
 	c := loadYaml(t, data)
 
@@ -123,6 +123,7 @@ spec:
   hosts:
   - ssh:
       address: "10.10.10.10"
+    role: manager
 `
 	c := loadYaml(t, data)
 
@@ -131,7 +132,6 @@ spec:
 }
 
 func TestHostAddressValidationWithInvalidHostname(t *testing.T) {
-	t.Skip("TODO: Validation is currently broken")
 	data := `
 apiVersion: launchpad.mirantis.com/mke/v1.4
 kind: mke
@@ -140,7 +140,8 @@ spec:
 	  version: 3.3.7
   hosts:
     - ssh:
-        address: "1-2-foo"
+        address: "1-2-foo.@"
+      role: manager
 `
 	c := loadYaml(t, data)
 
@@ -168,7 +169,6 @@ spec:
 }
 
 func TestHostSshPortValidation(t *testing.T) {
-	t.Skip("TODO: Validation is currently broken")
 	data := `
 apiVersion: launchpad.mirantis.com/mke/v1.4
 kind: mke
@@ -188,7 +188,6 @@ spec:
 }
 
 func TestHostRoleValidation(t *testing.T) {
-	t.Skip("TODO: Validation is currently broken")
 	data := `
 apiVersion: launchpad.mirantis.com/mke/v1.4
 kind: mke
@@ -305,7 +304,6 @@ spec:
 }
 
 func TestHostWinRMCACertPathValidation(t *testing.T) {
-	t.Skip("TODO: Validation is currently broken")
 	data := `
 apiVersion: launchpad.mirantis.com/mke/v1.4
 kind: mke
@@ -326,7 +324,6 @@ spec:
 }
 
 func TestHostWinRMCertPathValidation(t *testing.T) {
-	t.Skip("TODO: Validation is currently broken")
 	data := `
 apiVersion: launchpad.mirantis.com/mke/v1.4
 kind: mke
@@ -347,7 +344,6 @@ spec:
 }
 
 func TestHostWinRMKeyPathValidation(t *testing.T) {
-	t.Skip("TODO: Validation is currently broken")
 	data := `
 apiVersion: launchpad.mirantis.com/mke/v1.4
 kind: mke
@@ -409,7 +405,6 @@ spec:
 }
 
 func TestValidationWithMSRRole(t *testing.T) {
-	t.Skip("TODO: Validation is currently broken")
 	kf, _ := os.CreateTemp("", "testkey")
 	defer kf.Close()
 	t.Run("the role is not ucp, worker or msr", func(t *testing.T) {


### PR DESCRIPTION
- Added `dive` tag in order to validate the structs inside the Hosts slice; without that tag validator does not validate the individual host objects in Hosts slice
- Added `role: manager` for some tests because those tests were failing without role attribute
- Removed the lines added to skip the tests
- Added a special character to make an IP and a hostname invalid
- All the tests pass with the above changes