### PR TITLE
PRODENG-2548 Removed not needed make cleanup from the smoke GH

### DIFF
--- a/.github/workflows/smoke-test-full.yaml
+++ b/.github/workflows/smoke-test-full.yaml
@@ -19,5 +19,3 @@ jobs:
                 AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
               run: |
                 make smoke-full
-                clean-launchpad-chart
-

--- a/.github/workflows/smoke-test-small.yaml
+++ b/.github/workflows/smoke-test-small.yaml
@@ -22,5 +22,3 @@ jobs:
                 AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
               run: |
                 make smoke-small
-                make clean-launchpad-chart
-


### PR DESCRIPTION
- removed not needed make `clean-launchpad-chart` from the GH actions because the terratest Destroy will be called regardless

https://mirantis.jira.com/browse/PRODENG-2548