### PR TITLE
PRODENG-2566 sanitize MKE name/pass

### DIFF
--- a/.goreleaser.local.yml
+++ b/.goreleaser.local.yml
@@ -13,3 +13,11 @@ builds:
     - -X github.com/Mirantis/mcc/version.GitCommit={{ .FullCommit }}
     - -X github.com/Mirantis/mcc/version.Version={{ .Version }}
   binary: '{{ .ProjectName }}'
+  goos:
+    - linux
+    - darwin
+    - windows
+    - freebsd
+  goarch:
+    - amd64
+    - arm64

--- a/pkg/product/mke/phase/install_mke.go
+++ b/pkg/product/mke/phase/install_mke.go
@@ -104,11 +104,11 @@ func (p *InstallMKE) Run() error {
 	}
 
 	if p.Config.Spec.MKE.AdminUsername != "" {
-		installFlags.AddUnlessExist("--admin-username " + p.Config.Spec.MKE.AdminUsername)
+		installFlags.AddUnlessExist(fmt.Sprintf("--admin-username='%s'", p.Config.Spec.MKE.AdminUsername))
 	}
 
 	if p.Config.Spec.MKE.AdminPassword != "" {
-		installFlags.AddUnlessExist("--admin-password " + p.Config.Spec.MKE.AdminPassword)
+		installFlags.AddUnlessExist(fmt.Sprintf("--admin-password='%s'", p.Config.Spec.MKE.AdminPassword))
 	}
 
 	installCmd := h.Configurer.DockerCommandf("run %s %s install %s", runFlags.Join(), image, installFlags.Join())


### PR DESCRIPTION
- MKE username/password pass to MKE bootstrapper are now fmt and quoted

ALSO

- local goreleaser now has platforms, otherwise freebsd doesn't build