### PR TITLE
PRODENG-2569 Set the rnd string generator to be only alpha-numerical

### DIFF
--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -44,16 +44,11 @@ func TestSmallCluster(t *testing.T) {
 		"WrkUbuntu22":  test.Platforms["Ubuntu22"].GetWorker(),
 	}
 
-	uTestId, err := test.GenerateRandomString(5)
-	if err != nil {
-		t.Fatal(err)
-	}
+	uTestId := test.GenerateRandomAlphaNumericString(5)
+
 	name := fmt.Sprintf("smoke-%s", uTestId)
 
-	rndPassword, err := test.GenerateRandomString(12)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rndPassword := test.GenerateRandomAlphaNumericString(12)
 
 	MKE_CONNECT["password"] = rndPassword
 
@@ -113,16 +108,11 @@ func TestSupportedMatrixCluster(t *testing.T) {
 		"WrkOracle9":  test.Platforms["Oracle9"].GetWorker(),
 	}
 
-	uTestId, err := test.GenerateRandomString(5)
-	if err != nil {
-		t.Fatal(err)
-	}
+	uTestId := test.GenerateRandomAlphaNumericString(5)
+
 	name := fmt.Sprintf("smoke-%s", uTestId)
 
-	rndPassword, err := test.GenerateRandomString(12)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rndPassword := test.GenerateRandomAlphaNumericString(12)
 
 	MKE_CONNECT["password"] = rndPassword
 

--- a/test/util.go
+++ b/test/util.go
@@ -1,16 +1,15 @@
 package test
 
 import (
-	"crypto/rand"
-	"encoding/base64"
+	"math/rand"
 )
 
-// GenerateRandomString generates a random string of a given length
-func GenerateRandomString(length int) (string, error) {
-	bytes := make([]byte, length)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		return "", err
+// GenerateRandomAlphaNumericString generates a random string of a given length with only alphanumeric values
+func GenerateRandomAlphaNumericString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	result := make([]byte, length)
+	for i := 0; i < length; i++ {
+		result[i] = charset[rand.Intn(len(charset))]
 	}
-	return base64.URLEncoding.EncodeToString(bytes)[:length], nil
+	return string(result)
 }


### PR DESCRIPTION
- Now the random string generator will return only alpha-numerical string

https://mirantis.jira.com/browse/PRODENG-2569