### PR TITLE
PRODENG-2582 Fixed launchpad-download due to new tag version style

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -135,12 +135,12 @@ func latestTag(timeout time.Duration) string {
 
 	if strings.Contains(Version, "-") {
 		// Current is pre, assume pre is accepted as latest
-		return versions[len(versions)-1].String()
+		return versions[len(versions)-1].Original()
 	}
 
 	for i := len(versions) - 1; i >= 0; i-- {
-		if !strings.Contains(versions[i].String(), "-") {
-			return versions[i].String()
+		if !strings.Contains(versions[i].Original(), "-") {
+			return versions[i].Original()
 		}
 	}
 


### PR DESCRIPTION
- Retrieving the actual latest tag name without the Hashicorp's library to prune the "v" in the tag in Mirantis/Launchpad

https://mirantis.jira.com/browse/PRODENG-2582