### PR TITLE
PRODENG-2604 Fixed Jenkinsfile upload to s3 AWS creds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,17 @@
+release_creds = [
+  [
+    $class: 'AmazonWebServicesCredentialsBinding',
+    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+    secretKeyVariable: 'AWS_SECRET_ACCESS_KEY',
+    credentialsId: 'tools-aws-de-production-access-keys',
+  ],
+  usernamePassword(
+    usernameVariable: 'GITHUB_USERNAME',
+    passwordVariable: 'GITHUB_TOKEN',
+    credentialsId   : 'tools-github-up',
+  ),
+]
+
 pipeline {
   parameters {
     string(
@@ -74,13 +88,7 @@ spec:
           }
         }
         container("jnlp") {
-          withCredentials([
-            usernamePassword(
-              usernameVariable: 'GITHUB_USERNAME',
-              passwordVariable: 'GITHUB_TOKEN',
-              credentialsId   : 'tools-github-up',
-            ),
-          ]) {
+          withCredentials(release_creds) {
             sh (
               label: "creating release",
               script: """

--- a/upload_s3.sh
+++ b/upload_s3.sh
@@ -3,5 +3,5 @@
 TAG=$(git describe --tags --abbrev=0)
 
 for file in dist/release/*; do
-    aws s3 cp "$file" s3://get-mirantis.com/launchpad/$TAG/"$(basename "$file")" --recursive
+    aws s3 cp "$file" s3://get-mirantis.com/launchpad/$TAG/"$(basename "$file")"
 done


### PR DESCRIPTION
- Added AWS credentials to the Jenkinsfile so the s3 script can upload the binaries
- Removed --recursive flag from the upload_s3.sh script because it's not needed

https://mirantis.jira.com/browse/PRODENG-2604