### PR TITLE
PRODENG-2605 GH Smoke tests actions run conditions updated

### DIFF
--- a/.github/workflows/smoke-test-full.yaml
+++ b/.github/workflows/smoke-test-full.yaml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '**.go'
+      - '**.tf'
+      - '.terraform.lock.hcl'
+      - go.mod
+      - go.sum
 
 jobs:
     smoke-full:

--- a/.github/workflows/smoke-test-small.yaml
+++ b/.github/workflows/smoke-test-small.yaml
@@ -4,9 +4,10 @@ on:
   pull_request:
     paths:
       - '**.go'
+      - '**.tf'
+      - '.terraform.lock.hcl'
       - go.mod
       - go.sum
-      - Makefile
 
 jobs:
     smoke-small:


### PR DESCRIPTION
1. Updated both GH actions Small and Full Smoke tests to run only when there is one of those file changes:
      - '**.go'
      - '**.tf'
      - '.terraform.lock.hcl'
      - go.mod
      - go.sum

https://mirantis.jira.com/browse/PRODENG-2605