### PR TITLE
PRODENG-2607 Fixed osHost OS + Arch interpretation for binary download

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -43,18 +43,8 @@ func (a *Asset) IsForHost() bool {
 		return false
 	}
 
-	goos := runtime.GOOS
-	if goos == "windows" {
-		goos = "win"
-	}
-
-	arch := runtime.GOARCH
-	if arch == "amd64" {
-		arch = "x64"
-	}
-
-	parts := strings.Split(strings.TrimSuffix(a.Name, ".exe"), "-")
-	return parts[1] == goos && parts[2] == arch
+	parts := strings.Split(strings.TrimSuffix(a.Name, ".exe"), "_")
+	return parts[1] == runtime.GOOS && parts[2] == runtime.GOARCH
 }
 
 // LaunchpadRelease describes a launchpad release.


### PR DESCRIPTION
1. We've changed how our artifacts look from `launchpad-darwin-arm64` to `launchpad_darwin_amd64_1.5.6` which caused breakage in osHost() function.
2. I've fixed the osHost() function to work with the new style of artifacts 

https://mirantis.jira.com/browse/PRODENG-2607