### PR TITLE
commenting out MCR post-upgrade version check PRODENG-2615

### DIFF
--- a/pkg/product/mke/phase/upgrade_mcr.go
+++ b/pkg/product/mke/phase/upgrade_mcr.go
@@ -204,9 +204,9 @@ func (p *UpgradeMCR) upgradeMCR(h *api.Host) error {
 		}
 	}
 
-	if currentVersion != p.Config.Spec.MCR.Version {
-		return fmt.Errorf("%s: %w: container runtime version not %s after upgrade", h, errVersionMismatch, p.Config.Spec.MCR.Version)
-	}
+	// if currentVersion != p.Config.Spec.MCR.Version {
+	// 	return fmt.Errorf("%s: %w: container runtime version not %s after upgrade", h, errVersionMismatch, p.Config.Spec.MCR.Version)
+	// }
 
 	log.Infof("%s: upgraded to mirantis container runtime version %s", h, p.Config.Spec.MCR.Version)
 	h.Metadata.MCRVersion = p.Config.Spec.MCR.Version


### PR DESCRIPTION
## Who is asking for this:

Testing Team

## What needs to be done for this ticket to be closed:

- a custom launchpad build that omits post-upgrade version check to workaround TESTING-1833 /  PRODENG-2615

## Why is this needed:

- update to install.sh causes version check to fail

## Who is reviewing this ticket:

@pgedara 
