### PR TITLE
Revert "PRODENG-2599 Restarting containerd on MCR upgrade"

### DIFF
--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -7,13 +7,11 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Mirantis/mcc/pkg/constant"
 	common "github.com/Mirantis/mcc/pkg/product/common/api"
 	"github.com/Mirantis/mcc/pkg/util/iputil"
 	escape "github.com/alessio/shellescape"
-	"github.com/avast/retry-go"
 	"github.com/k0sproject/rig/exec"
 	"github.com/k0sproject/rig/os"
 	log "github.com/sirupsen/logrus"
@@ -72,29 +70,6 @@ func (c LinuxConfigurer) InstallMCR(h os.Host, scriptPath string, engineConfig c
 func (c LinuxConfigurer) RestartMCR(h os.Host) error {
 	if err := c.riglinux.RestartService(h, "docker"); err != nil {
 		return fmt.Errorf("restart docker service: %w", err)
-	}
-	return nil
-}
-
-// RestartContainerd restarts containerd.
-func (c LinuxConfigurer) RestartContainerd(h os.Host) error {
-	if err := c.riglinux.RestartService(h, "containerd"); err != nil {
-		return fmt.Errorf("restart containerd service: %w", err)
-	}
-	err := retry.Do(
-		func() error {
-			if err := h.Exec(c.DockerCommandf("ps")); err != nil {
-				return fmt.Errorf("failed to run `docker ps` after containerd restart: %w", err)
-			}
-			return nil
-		},
-		retry.DelayType(retry.CombineDelay(retry.FixedDelay, retry.RandomDelay)),
-		retry.MaxJitter(time.Second*2),
-		retry.Delay(time.Second*3),
-		retry.Attempts(10),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to restart containerd service: %w", err)
 	}
 	return nil
 }

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -130,28 +130,6 @@ func (c WindowsConfigurer) RestartMCR(h os.Host) error {
 	return nil
 }
 
-// RestartContainerd restarts containerd service.
-func (c WindowsConfigurer) RestartContainerd(h os.Host) error {
-	_ = h.Exec("net stop containerd")
-	_ = h.Exec("net start containerd")
-	err := retry.Do(
-		func() error {
-			if err := h.Exec(c.DockerCommandf("ps")); err != nil {
-				return fmt.Errorf("failed to run docker ps after restart: %w", err)
-			}
-			return nil
-		},
-		retry.DelayType(retry.CombineDelay(retry.FixedDelay, retry.RandomDelay)),
-		retry.MaxJitter(time.Second*2),
-		retry.Delay(time.Second*3),
-		retry.Attempts(10),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to restart containerd service: %w", err)
-	}
-	return nil
-}
-
 // ResolveInternalIP resolves internal ip from private interface.
 func (c WindowsConfigurer) ResolveInternalIP(h os.Host, privateInterface, publicIP string) (string, error) {
 	output, err := c.interfaceIP(h, privateInterface)

--- a/pkg/product/mke/api/configurer.go
+++ b/pkg/product/mke/api/configurer.go
@@ -24,7 +24,6 @@ type HostConfigurer interface {
 	UninstallMCR(os.Host, string, common.MCRConfig) error
 	DockerCommandf(template string, args ...interface{}) string
 	RestartMCR(os.Host) error
-	RestartContainerd(os.Host) error
 	AuthenticateDocker(h os.Host, user, pass, repo string) error
 	LocalAddresses(os.Host) ([]string, error)
 	ValidateLocalhost(os.Host) error

--- a/pkg/product/mke/phase/upgrade_mcr.go
+++ b/pkg/product/mke/phase/upgrade_mcr.go
@@ -176,10 +176,6 @@ func (p *UpgradeMCR) upgradeMCR(h *api.Host) error {
 		return fmt.Errorf("retry count exceeded: %w", err)
 	}
 
-	if err := h.Configurer.RestartContainerd(h); err != nil {
-		return fmt.Errorf("%s: failed to restart containerd: %w", h, err)
-	}
-
 	// TODO: This exercise is duplicated in InstallMCR, maybe
 	// combine into some kind of "EnsureVersion"
 	currentVersion, err := h.MCRVersion()


### PR DESCRIPTION
Reverts Mirantis/mcc#458
We do revert this change because we've decided along with the Engine and Test team that there are too many containerd restarts