### PR TITLE
PRODENG-2626 Fixed removal of /var/lib/kubelet/ on MSR host

### DIFF
--- a/pkg/product/mke/phase/install_msr.go
+++ b/pkg/product/mke/phase/install_msr.go
@@ -119,7 +119,7 @@ func (p *InstallMSR) Run() error {
 // CleanUp removes remnants of MSR after a failed installation.
 func (p *InstallMSR) CleanUp() {
 	log.Infof("Cleaning up for '%s'", p.Title())
-	if err := msr.Destroy(p.leader); err != nil {
+	if err := msr.Destroy(p.leader, p.Config); err != nil {
 		log.Warnf("Error while cleaning-up resources for '%s': %s", p.Title(), err.Error())
 	}
 }

--- a/pkg/product/mke/phase/remove_nodes.go
+++ b/pkg/product/mke/phase/remove_nodes.go
@@ -131,7 +131,7 @@ func (p *RemoveNodes) Prepare(config interface{}) error {
 func (p *RemoveNodes) Run() error {
 	swarmLeader := p.Config.Spec.SwarmLeader()
 	if len(p.cleanupMSRs) > 0 {
-		err := msr.Cleanup(p.cleanupMSRs, swarmLeader)
+		err := msr.Cleanup(p.cleanupMSRs, swarmLeader, p.Config)
 		if err != nil {
 			return fmt.Errorf("failed to cleanup MSR nodes: %w", err)
 		}

--- a/pkg/product/mke/phase/uninstall_mke.go
+++ b/pkg/product/mke/phase/uninstall_mke.go
@@ -62,7 +62,7 @@ func (p *UninstallMKE) Run() error {
 		return nil
 	})
 
-	workers := p.Config.Spec.Workers()
+	workers := p.Config.Spec.WorkersAndMSRs()
 	_ = workers.ParallelEach(func(h *api.Host) error {
 		if err := h.Reboot(); err != nil {
 			log.Errorf("%s: failed to reboot the host: %v", h, err)

--- a/pkg/product/mke/phase/uninstall_msr.go
+++ b/pkg/product/mke/phase/uninstall_msr.go
@@ -36,7 +36,7 @@ func (p *UninstallMSR) Run() error {
 			msrHosts = append(msrHosts, h)
 		}
 	}
-	if err := msr.Cleanup(msrHosts, swarmLeader); err != nil {
+	if err := msr.Cleanup(msrHosts, swarmLeader, p.Config); err != nil {
 		return fmt.Errorf("failed to clean up MSR: %w", err)
 	}
 	return nil


### PR DESCRIPTION
-  Now removing successfully the /var/lib/kubelet off of MSR hosts
- We do reboot the MSR hosts as well after MKE uninstall

https://mirantis.jira.com/browse/PRODENG-2626