### PR TITLE
Add option for disabling the ASCII logo

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -45,6 +45,11 @@ func NewApplyCommand() *cli.Command {
 				Hidden: true,
 			},
 			&cli.BoolFlag{
+				Name:  "disable-logo",
+				Usage: "Disable printing of the Mirantis logo",
+				Value: false,
+			},
+			&cli.BoolFlag{
 				Name:  "force-upgrade",
 				Usage: "force upgrade to run on compatible components, even if it doesn't look necessary",
 				Value: false,
@@ -80,7 +85,9 @@ func NewApplyCommand() *cli.Command {
 			}
 
 			if isatty.IsTerminal(os.Stdout.Fd()) {
-				os.Stdout.WriteString(logo.Logo)
+				if !ctx.Bool("disable-logo") {
+					os.Stdout.WriteString(logo.Logo)
+				}
 				fmt.Fprintf(os.Stdout, "   Mirantis Launchpad (c) 2022 Mirantis, Inc.                          %s\n\n", version.Version)
 			}
 


### PR DESCRIPTION
Sometimes you don't want a logo, cause it messes up your terminal output in your test cases that are deploying stuff with `launchpad apply`.

# Manual test
```
bin/launchpad apply --disable-logo
INFO Note: The configuration has been migrated from a previous version
INFO       to see the migrated configuration use: launchpad describe config
   Mirantis Launchpad (c) 2022 Mirantis, Inc.                          0.0.0

INFO ==> Running phase: Check For Upgrades
WARN a newer version of MKE is available: 3.7.8 (installing 3.6.1)
WARN a newer version of MSR is available: 2.9.18 (installing 2.9.10)
INFO ==> Running phase: Open Remote Connection

# vs.

 bin/launchpad apply
INFO Note: The configuration has been migrated from a previous version
INFO       to see the migrated configuration use: launchpad describe config


                       ..,,,,,..
              .:i1fCG0088@@@@@880GCLt;,               .,,::::::,,...
         ,;tC0@@@@@@@@@@@@@@@@@@@@@@@@@0:,     .,:ii111i;:,,..
      ,;1ttt1;;::::;;itfCG8@@@@@@@@@i @@@@0fi1t111i;,.
     .,.                  .:1L0@@   @8GCft111ii1;
                               :f0CLft1i;i1tL . @8Cti:.               .,:,.
                           .:;i1111i;itC;  @@@@@@@@@@@80GCLftt11ttfLLLf1:.
                    .,:;ii1111i:,.    , G8@@@@@@@@@@@@@@@@@@@@@@@0Lt;,
            ...,,::;;;;::,.               ,;itfLCGGG0GGGCLft1;:.



   ;1:      i1, .1, .11111i:      .1i     :1;     ,1, i11111111: ;i   ;1111;
   G@GC:  1G0@i ;@1 ;@t:::;G0.   .0G8f    L@GC:   i@i :;;;@G;;;, C@ .80i:,:;
   C8 10CGC::@i :@i :@f:;;;CG.  .0G ,@L   f@.iGL, ;@;     @L     L@. tLft1;.
   G8   1;  ;@i ;@i :@L11C@t   ,08fffL@L  L@.  10fi@;    .@L     L@.    .:t@1
   C0       ;@i :@i :@i   ;Gf..0C     ,8L f@.   .f0@;    .8L     L8  fft11fG;
   ..        .   .   ..     ,..,        , ..      ..      ..     ..  .,:::,

   Mirantis Launchpad (c) 2022 Mirantis, Inc.                          0.0.0

INFO ==> Running phase: Check For Upgrades
WARN a newer version of MKE is available: 3.7.8 (installing 3.6.1)
WARN a newer version of MSR is available: 2.9.18 (installing 2.9.10)
INFO ==> Running phase: Open Remote Connection
```