### PR TITLE
PRODENG-2686 MKE Health now pings all managers

### DIFF
--- a/pkg/product/mke/phase/install_msr.go
+++ b/pkg/product/mke/phase/install_msr.go
@@ -41,7 +41,9 @@ func (p *InstallMSR) Run() error {
 		h.MSRMetadata = &api.MSRMetadata{}
 	}
 
-	err := p.Config.Spec.CheckMKEHealthRemote(h)
+	managers := p.Config.Spec.Managers()
+
+	err := p.Config.Spec.CheckMKEHealthRemote(managers)
 	if err != nil {
 		return fmt.Errorf("%s: failed to health check mke, try to set `--ucp-url` installFlag and check connectivity: %w", h, err)
 	}

--- a/pkg/product/mke/phase/upgrade_mcr.go
+++ b/pkg/product/mke/phase/upgrade_mcr.go
@@ -89,13 +89,13 @@ func (p *UpgradeMCR) upgradeMCRs() error {
 	for _, h := range managers {
 		err := p.upgradeMCR(h)
 		if err != nil {
-			return err
+			return fmt.Errorf("upgrade MCR failed. %w", err)
 		}
-		if p.Config.Spec.MKE.Metadata.Installed {
-			err := p.Config.Spec.CheckMKEHealthLocal(h)
-			if err != nil {
-				return fmt.Errorf("%s: %w", h, err)
-			}
+	}
+	if p.Config.Spec.MKE.Metadata.Installed {
+		err := p.Config.Spec.CheckMKEHealthLocal(managers)
+		if err != nil {
+			return fmt.Errorf("checkMKEHealthLocal failed. %w", err)
 		}
 	}
 

--- a/pkg/product/mke/phase/upgrade_msr.go
+++ b/pkg/product/mke/phase/upgrade_msr.go
@@ -33,7 +33,9 @@ func (p *UpgradeMSR) ShouldRun() bool {
 func (p *UpgradeMSR) Run() error {
 	h := p.Config.Spec.MSRLeader()
 
-	err := p.Config.Spec.CheckMKEHealthRemote(h)
+	managers := p.Config.Spec.Managers()
+
+	err := p.Config.Spec.CheckMKEHealthRemote(managers)
 	if err != nil {
 		return fmt.Errorf("%s: failed to health check mke, try to set `--ucp-url` installFlag and check connectivity: %w", h, err)
 	}

--- a/pkg/product/mke/phase/validate_mke_health.go
+++ b/pkg/product/mke/phase/validate_mke_health.go
@@ -32,10 +32,10 @@ func (p *ValidateMKEHealth) Title() string {
 // launchpad phases, should be used when installing products that depend
 // on MKE, such as MSR.
 func (p *ValidateMKEHealth) Run() error {
-	// Issue a health check to the MKE san host until we receive an 'ok' status
-	swarmLeader := p.Config.Spec.SwarmLeader()
+	// Issue a health check to the MKE local address managers until we receive an 'ok' status
+	managers := p.Config.Spec.Managers()
 
-	if err := p.Config.Spec.CheckMKEHealthLocal(swarmLeader); err != nil {
+	if err := p.Config.Spec.CheckMKEHealthLocal(managers); err != nil {
 		return fmt.Errorf("%w: failed to validate MKE health: %w", errValidationFailed, err)
 	}
 


### PR DESCRIPTION
- Now both functions _ CheckMKEHealthRemote_ and CheckMKEHealthLocal will ping a list of hosts passed to them.
- Created a common function which solo purpose is to ping the _host__ping endpoint

https://mirantis.jira.com/browse/PRODENG-2686