### PR TITLE
PRODENG-2686 Fix MSR3 for new healthcheck interface

### DIFF
--- a/pkg/product/mke/phase/install_msr3.go
+++ b/pkg/product/mke/phase/install_msr3.go
@@ -110,7 +110,7 @@ func (p *InstallOrUpgradeMSR3) Run() error {
 		}
 	}
 
-	if err := p.Config.Spec.CheckMKEHealthRemote(h); err != nil {
+	if err := p.Config.Spec.CheckMKEHealthRemote([]*api.Host{h}); err != nil {
 		return fmt.Errorf("%s: failed to health check mke, try to set `--ucp-url` installation flag and check connectivity: %w", h, err)
 	}
 


### PR DESCRIPTION
- MKEHealthCheck interface now takes a list of hosts
- Error exists because PR was not rebased on the MSR3 changes before being merged