### PR TITLE
PRODENG-2654 MSR without MKE fails config validate

### DIFF
--- a/pkg/product/mke/api/cluster_spec_test.go
+++ b/pkg/product/mke/api/cluster_spec_test.go
@@ -68,7 +68,7 @@ func TestMKEClusterSpecMKEURLWithNoMSRMetadata(t *testing.T) {
 			manager,
 			msr2,
 		},
-		MKE: &MKEConfig{},
+		MKE:  &MKEConfig{},
 		MSR2: &MSR2Config{},
 	}
 
@@ -83,7 +83,7 @@ func TestMKEClusterSpecMSR2URLWithNoMSRMetadata(t *testing.T) {
 			manager,
 			msr2,
 		},
-		MKE: &MKEConfig{},
+		MKE:  &MKEConfig{},
 		MSR2: &MSR2Config{},
 	}
 
@@ -116,7 +116,7 @@ func TestMKEClusterSpecMSR2URLWithoutExternalURL(t *testing.T) {
 				MSR2Metadata: &MSR2Metadata{Installed: true},
 			},
 		},
-		MKE: &MKEConfig{},
+		MKE:  &MKEConfig{},
 		MSR2: &MSR2Config{},
 	}
 	url, err := spec.MSR2URL()

--- a/pkg/product/mke/api/cluster_test.go
+++ b/pkg/product/mke/api/cluster_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/Mirantis/mcc/pkg/config/migration"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -30,7 +28,6 @@ import (
 	_ "github.com/Mirantis/mcc/pkg/config/migration/v1beta2"
 	// needed to load the migrators.
 	_ "github.com/Mirantis/mcc/pkg/config/migration/v1beta3"
-	"github.com/Mirantis/mcc/pkg/constant"
 	validator "github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -46,17 +43,18 @@ spec:
   hosts:
     - ssh:
         address: 10.0.0.1
-				keyPath: ` + kf.Name() + `
+        keyPath: ` + kf.Name() + `
       role: manager
     - ssh:
         address: 10.0.0.2
-				keyPath: ` + kf.Name() + `
+        keyPath: ` + kf.Name() + `
       role: worker
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
 `
 	c := loadYaml(t, data)
 	err := c.Validate()
+
 	require.NoError(t, err)
 }
 
@@ -64,96 +62,95 @@ func TestHostRequireManagerValidationFail(t *testing.T) {
 	kf, _ := os.CreateTemp("", "testkey")
 	defer kf.Close()
 	data := `
-apiVersion: "launchpad.mirantis.com/mke/v1.4"
+apiVersion: "launchpad.mirantis.com/mke/v1.6"
 kind: mke
 spec:
   hosts:
     - ssh:
         address: 10.0.0.1
-				keyPath: ` + kf.Name() + `
+        keyPath: ` + kf.Name() + `
       role: worker
     - ssh:
         address: 10.0.0.2
-				keyPath: ` + kf.Name() + `
+        keyPath: ` + kf.Name() + `
       role: worker
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
 `
 	c := loadYaml(t, data)
 	err := c.Validate()
-	require.Error(t, err)
 
+	require.Error(t, err)
 	validateErrorField(t, err, "hosts")
 }
 
 func TestNonExistingHostsFails(t *testing.T) {
 	data := `
-apiVersion: "launchpad.mirantis.com/mke/v1.4"
+apiVersion: "launchpad.mirantis.com/mke/v1.6"
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
 `
 	c := loadYaml(t, data)
 	err := c.Validate()
 	require.Error(t, err)
-
 	validateErrorField(t, err, "Hosts")
 }
 
 func TestHostAddressValidationWithInvalidIP(t *testing.T) {
 	data := `
-apiVersion: launchpad.mirantis.com/mke/v1.4
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
   - ssh:
       address: "512.1.2.3.@"
     role: manager
 `
 	c := loadYaml(t, data)
-
 	err := c.Validate()
+
 	require.Error(t, err)
 	validateErrorField(t, err, "Address")
 }
 
 func TestHostAddressValidationWithValidIP(t *testing.T) {
 	data := `
-apiVersion: launchpad.mirantis.com/mke/v1.4
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
   - ssh:
       address: "10.10.10.10"
     role: manager
 `
 	c := loadYaml(t, data)
-
 	err := c.Validate()
+
 	require.NotContains(t, getAllErrorFields(err), "Address")
 }
 
 func TestHostAddressValidationWithInvalidHostname(t *testing.T) {
 	data := `
-apiVersion: launchpad.mirantis.com/mke/v1.4
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
     - ssh:
         address: "1-2-foo.@"
       role: manager
 `
 	c := loadYaml(t, data)
-
 	err := c.Validate()
+
 	require.Error(t, err)
 	validateErrorField(t, err, "Address")
 }
@@ -163,26 +160,26 @@ func TestHostAddressValidationWithValidHostname(t *testing.T) {
 apiVersion: launchpad.mirantis.com/v1
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
     - ssh:
         address: "foo.example.com"
 `
 	c := loadYaml(t, data)
-
 	err := c.Validate()
+
 	require.NotContains(t, getAllErrorFields(err), "Address")
 
 }
 
 func TestHostSshPortValidation(t *testing.T) {
 	data := `
-apiVersion: launchpad.mirantis.com/mke/v1.4
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
     - ssh:
         address: "1.2.3.4"
@@ -191,17 +188,18 @@ spec:
 `
 	c := loadYaml(t, data)
 	err := c.Validate()
+
 	require.Error(t, err)
 	validateErrorField(t, err, "Port")
 }
 
 func TestHostRoleValidation(t *testing.T) {
 	data := `
-apiVersion: launchpad.mirantis.com/mke/v1.4
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
   - address: "1.2.3.4"
     ssh:
@@ -210,17 +208,18 @@ spec:
 `
 	c := loadYaml(t, data)
 	err := c.Validate()
+
 	require.Error(t, err)
 	validateErrorField(t, err, "Role")
 }
 
 func TestHostWithComplexMCRConfig(t *testing.T) {
 	data := `
-apiVersion: launchpad.mirantis.com/mke/v1.4
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
   - ssh:
       address: "1.2.3.4"
@@ -233,93 +232,18 @@ spec:
         max-files: 5
 `
 	c := loadYaml(t, data)
-
 	_, err := json.Marshal(c.Spec.Hosts[0].DaemonConfig)
+
 	require.NoError(t, err)
-}
-
-func TestMigrateFromV1Beta1(t *testing.T) {
-	logrus.SetLevel(logrus.DebugLevel)
-
-	data := `
-apiVersion: launchpad.mirantis.com/v1beta1
-kind: mke
-spec:
-	ucp:
-	  version: 3.3.7
-  engine:
-    installURL: http://example.com/
-  hosts:
-  - address: "1.2.3.4"
-    sshPort: 9022
-    sshKeyPath: /path/to/nonexisting
-    user: foofoo
-    role: manager
-`
-	c := loadAndMigrateYaml(t, data)
-	err := c.Validate()
-	require.NoError(t, err)
-	require.Equal(t, "launchpad.mirantis.com/mke/v1.6", c.APIVersion)
-
-	require.Equal(t, c.Spec.MCR.InstallURLLinux, "http://example.com/")
-	require.Equal(t, c.Spec.Hosts[0].SSH.Port, 9022)
-	require.Equal(t, c.Spec.Hosts[0].SSH.User, "foofoo")
-}
-
-func TestMigrateFromV1Beta2(t *testing.T) {
-	data := `
-apiVersion: launchpad.mirantis.com/v1beta2
-kind: mke
-spec:
-  ucp:
-	  version: 3.3.7
-  engine:
-    installURL: http://example.com/
-  hosts:
-  - address: "1.2.3.4"
-    role: manager
-    winRM:
-      user: foo
-      password: foo
-`
-	c := loadAndMigrateYaml(t, data)
-	require.NoError(t, c.Validate())
-	require.Equal(t, "launchpad.mirantis.com/mke/v1.6", c.APIVersion)
-}
-
-func TestMigrateFromV1Beta1WithoutInstallURL(t *testing.T) {
-	data := `
-apiVersion: launchpad.mirantis.com/v1beta1
-kind: mke
-spec:
-	ucp:
-	  version: 3.3.7
-  engine:
-    version: 1.2.3
-  hosts:
-  - address: "1.2.3.4"
-    sshPort: 9022
-    sshKeyPath: /path/to/nonexisting
-    user: foofoo
-    role: manager
-`
-	c := loadAndMigrateYaml(t, data)
-	err := c.Validate()
-	require.NoError(t, err)
-	require.Equal(t, "launchpad.mirantis.com/mke/v1.6", c.APIVersion)
-
-	require.Equal(t, constant.MCRInstallURLLinux, c.Spec.MCR.InstallURLLinux)
-	require.Equal(t, 9022, c.Spec.Hosts[0].SSH.Port)
-	require.Equal(t, "foofoo", c.Spec.Hosts[0].SSH.User)
 }
 
 func TestHostWinRMCACertPathValidation(t *testing.T) {
 	data := `
-apiVersion: launchpad.mirantis.com/mke/v1.4
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
     - role: manager
       winRM:
@@ -327,19 +251,19 @@ spec:
         caCertPath: /path/to/nonexisting
 `
 	c := loadYaml(t, data)
-
 	err := c.Validate()
+
 	require.Error(t, err)
 	validateErrorField(t, err, "CACertPath")
 }
 
 func TestHostWinRMCertPathValidation(t *testing.T) {
 	data := `
-apiVersion: launchpad.mirantis.com/mke/v1.4
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
     - role: manager
       winRM:
@@ -347,38 +271,38 @@ spec:
         certPath: /path/to/nonexisting
 `
 	c := loadYaml(t, data)
-
 	err := c.Validate()
+
 	require.Error(t, err)
 	validateErrorField(t, err, "CertPath")
 }
 
 func TestHostWinRMKeyPathValidation(t *testing.T) {
 	data := `
-apiVersion: launchpad.mirantis.com/mke/v1.4
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
     - role: manager
       winRM:
         keyPath: /path/to/nonexisting
 `
 	c := loadYaml(t, data)
-
 	err := c.Validate()
+
 	require.Error(t, err)
 	validateErrorField(t, err, "KeyPath")
 }
 
 func TestHostSSHDefaults(t *testing.T) {
 	data := `
-apiVersion: launchpad.mirantis.com/mke/v1.4
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
     - ssh:
         address: "1.2.3.4"
@@ -395,8 +319,8 @@ func TestHostWinRMDefaults(t *testing.T) {
 apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
+  mke:
+    version: 3.7.12
   hosts:
     - role: manager
       winRM:
@@ -406,7 +330,6 @@ spec:
 	c := loadYaml(t, data)
 
 	require.NoError(t, c.Validate())
-
 	require.Equal(t, c.Spec.Hosts[0].WinRM.User, "User")
 	require.Equal(t, c.Spec.Hosts[0].WinRM.Port, 5985)
 	require.Equal(t, c.Spec.Hosts[0].WinRM.UseNTLM, false)
@@ -419,23 +342,24 @@ func TestValidationWithMSR2Role(t *testing.T) {
 	defer kf.Close()
 	t.Run("the role is not ucp, worker or msr2", func(t *testing.T) {
 		data := `
-apiVersion: launchpad.mirantis.com/mke/v1.4
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke
 spec:
-	mke:
-	  version: 3.3.7
-	msr:
-	  version: 2.8.5
+  mke:
+    version: 3.7.12
+  msr2:
+    version: 2.9.20
   hosts:
     - ssh:
         address: "10.0.0.1"
-				keyPath: ` + kf.Name() + `
+        keyPath: ` + kf.Name() + `
       role: weirdrole
     - ssh:
         address: "10.0.0.2"
       role: manager
 `
 		c := loadYaml(t, data)
+
 		require.Error(t, c.Validate())
 	})
 
@@ -444,22 +368,47 @@ spec:
 apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke+msr
 spec:
-	mke:
-	  version: 3.3.7
-	msr2:
-	  version: 2.8.5
+  mke:
+    version: 3.7.12
+  msr2:
+    version: 2.9.20
   hosts:
     - ssh:
         address: "10.0.0.1"
-				keyPath: ` + kf.Name() + `
+        keyPath: ` + kf.Name() + `
       role: msr2
     - ssh:
         address: "10.0.0.2"
-				keyPath: ` + kf.Name() + `
+        keyPath: ` + kf.Name() + `
       role: manager
 `
 		c := loadYaml(t, data)
+
 		require.NoError(t, c.Validate())
+	})
+
+	t.Run("the msr2 role is missing", func(t *testing.T) {
+		data := `
+apiVersion: launchpad.mirantis.com/mke/v1.6
+kind: mke+msr
+spec:
+  mke:
+    version: 3.7.12
+  msr2:
+    version: 2.9.20
+  hosts:
+    - ssh:
+        address: "10.0.0.1"
+        keyPath: ` + kf.Name() + `
+      role: worker
+    - ssh:
+        address: "10.0.0.2"
+        keyPath: ` + kf.Name() + `
+      role: manager
+`
+		c := loadYaml(t, data)
+
+		require.Error(t, c.Validate())
 	})
 
 }
@@ -476,21 +425,21 @@ func TestValidationWithMSR3(t *testing.T) {
 apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke+msr
 spec:
-	mke:
-	  version: 3.3.7
-	msr3:
-	  version: 3.1.4
-	  storageURL: "https://example.com"
-	  storageClassType: "nfs"
-	  crd:
-	    apiVersion: "msr.mirantis.com/v1"
-		  kind: "MSR"
-		  spec:
-		    logLevel: "debug"
+  mke:
+    version: 3.7.5
+  msr3:
+    version: 3.1.6
+    storageURL: "https://example.com"
+    storageClassType: "nfs"
+    crd:
+      apiVersion: "msr.mirantis.com/v1"
+      kind: "MSR"
+      spec:
+        logLevel: "debug"
   hosts:
     - ssh:
         address: "10.0.0.1"
-      role: msr3
+      role: worker
     - ssh:
         address: "10.0.0.2"
       role: manager
@@ -515,11 +464,11 @@ spec:
 apiVersion: launchpad.mirantis.com/mke/v1.5
 kind: mke+msr
 spec:
-	mke:
-	  version: 3.3.7
-	msr3:
-	  version: 3.1.4
-	  storageClassType: "nfs"
+  mke:
+    version: 3.7.12
+  msr3:
+    version: 3.1.6
+    storageClassType: "nfs"
   hosts:
     - ssh:
         address: "10.0.0.1"
@@ -536,15 +485,15 @@ spec:
 
 	t.Run("storageClassType must be one of the supported types", func(t *testing.T) {
 		data := `
-apiVersion: launchpad.mirantis.com/mke/v1.5
+apiVersion: launchpad.mirantis.com/mke/v1.6
 kind: mke+msr
 spec:
-	mke:
-	  version: 3.3.7
-	msr3:
-	  version: 3.1.4
-	  storageURL: "https://example.com"
-	  storageClassType: "not-supported"
+  mke:
+    version: 3.7.12
+  msr3:
+    version: 3.1.6
+    storageURL: "https://example.com"
+    storageClassType: "not-supported"
   hosts:
     - ssh:
         address: "10.0.0.1"
@@ -555,6 +504,7 @@ spec:
 `
 
 		c := loadYaml(t, data)
+
 		require.ErrorContains(t, c.Validate(), "StorageClassType", "oneof")
 	})
 }


### PR DESCRIPTION
- As both MSR2 and MSR3 require MKE, config validation will fail if
  msr2/msr3 blocks are in the config, but mke is not
- ClusterSpec validation handler combine

ALSO:

- Had to do a fair amount of unit test cleanup to get tests to pass:
   - fix MSR2 host & MSR testing
   - updated several test schema versions and product versions in test yaml
   - dropped really outdated migration tests for beta spec version
   - whitespace cleanup in test yaml (tabs & spaces)
   - standardized whitespace in test calls, so that they all look the same