### PR TITLE
PRODENG-2654 cannot get client-bundle if no MKE

### DIFF
--- a/pkg/product/mke/client_config.go
+++ b/pkg/product/mke/client_config.go
@@ -12,7 +12,7 @@ import (
 // ClientConfig downloads MKE client bundle.
 func (p *MKE) ClientConfig() error {
 	if p.ClusterConfig.Spec.MKE == nil {
-		return fmt.Errorf("%w; Cannot download client bundle as there is no MKE", api.ErrThereIsNoMKE)
+		return fmt.Errorf("%w; Cannot download client bundle as there is no MKE installation", api.ErrThereIsNoMKE)
 	}
 
 	manager := p.ClusterConfig.Spec.Managers()[0]


### PR DESCRIPTION
- the MKE client config (get client bundle) command doesn't work if there is no MKE configuration block