### PR TITLE
PRODENG-2702 mke uninstall activate fix

### DIFF
--- a/pkg/product/mke/api/cluster_spec_test.go
+++ b/pkg/product/mke/api/cluster_spec_test.go
@@ -68,7 +68,7 @@ func TestMKEClusterSpecMKEURLWithNoMSRMetadata(t *testing.T) {
 			manager,
 			msr2,
 		},
-		MKE: &MKEConfig{},
+		MKE:  &MKEConfig{},
 		MSR2: &MSR2Config{},
 	}
 
@@ -83,7 +83,7 @@ func TestMKEClusterSpecMSR2URLWithNoMSRMetadata(t *testing.T) {
 			manager,
 			msr2,
 		},
-		MKE: &MKEConfig{},
+		MKE:  &MKEConfig{},
 		MSR2: &MSR2Config{},
 	}
 
@@ -116,7 +116,7 @@ func TestMKEClusterSpecMSR2URLWithoutExternalURL(t *testing.T) {
 				MSR2Metadata: &MSR2Metadata{Installed: true},
 			},
 		},
-		MKE: &MKEConfig{},
+		MKE:  &MKEConfig{},
 		MSR2: &MSR2Config{},
 	}
 	url, err := spec.MSR2URL()

--- a/pkg/product/mke/phase/uninstall_mke.go
+++ b/pkg/product/mke/phase/uninstall_mke.go
@@ -24,6 +24,12 @@ func (p *UninstallMKE) Title() string {
 	return "Uninstall MKE components"
 }
 
+// ShouldRun should return true only when there is an installation to be
+// performed.
+func (p *UninstallMKE) ShouldRun() bool {
+	return p.Config.Spec.MKE != nil && p.Config.Spec.MKE.Metadata != nil && p.Config.Spec.MKE.Metadata.Installed
+}
+
 // Run the installer container.
 func (p *UninstallMKE) Run() error {
 	swarmLeader := p.Config.Spec.SwarmLeader()

--- a/pkg/product/mke/reset.go
+++ b/pkg/product/mke/reset.go
@@ -27,7 +27,7 @@ func (p *MKE) Reset() error {
 		phaseManager.AddPhase(&mke.UninstallMSR3{})
 	}
 
-	if p.ClusterConfig.Spec.MKE != nil && p.ClusterConfig.Spec.MKE.Metadata.Installed {
+	if p.ClusterConfig.Spec.MKE != nil {
 		phaseManager.AddPhases(
 			&mke.UninstallMKE{},
 		)


### PR DESCRIPTION
- MKE uninstall check in phase manager build for the reset command was testing if mke.Metadata.Installed, before it could be set.
- MKE uninstall phase now added as long as MKE config block is included
- MKE uninstall phase checks installed status before running

ALSO

- go fmt