### PR TITLE
PRODENG-2714 better MCR Only MKE checks

### DIFF
--- a/pkg/product/mke/phase/validate_facts.go
+++ b/pkg/product/mke/phase/validate_facts.go
@@ -216,6 +216,11 @@ var errInvalidDataPlane = errors.New("invalid data plane settings")
 
 // validateDataPlane checks if the calico data plane would get changed (VXLAN <-> VPIP).
 func (p *ValidateFacts) validateDataPlane() error {
+	if p.Config.Spec.MKE == nil {
+		log.Debug("No need to validate data plane settings as MKE isn't included.")
+		return nil
+	}
+
 	log.Debug("validating data plane settings")
 
 	idx := p.Config.Spec.MKE.InstallFlags.Index("--calico-vxlan")

--- a/pkg/product/mke/phase/validate_mke_health.go
+++ b/pkg/product/mke/phase/validate_mke_health.go
@@ -28,6 +28,12 @@ func (p *ValidateMKEHealth) Title() string {
 	return "Validating MKE Health"
 }
 
+// ShouldRun should return true only when there is an installation to be
+// performed.
+func (p *ValidateMKEHealth) ShouldRun() bool {
+	return p.Config.Spec.MKE != nil
+}
+
 // Run validates the health of MKE is sane before continuing with other
 // launchpad phases, should be used when installing products that depend
 // on MKE, such as MSR.


### PR DESCRIPTION
- more attempts to avoid MKE implementations on MCR only installs.
- moved some functionality in a phase to keep phase methods separate together for readability.