### PR TITLE
PRODENG-2717 More MKE/MSR config checks before running functionality

### DIFF
--- a/pkg/mke/mke.go
+++ b/pkg/mke/mke.go
@@ -253,10 +253,15 @@ func KubeAndHelmFromConfig(config *api.ClusterConfig) (*kubeclient.KubeClient, *
 var (
 	errNoManagersInConfig = errors.New("no managers found in config")
 	errInvalidConfig      = errors.New("invalid config")
+	errNoMKE              = errors.New("no MKE installation")
 )
 
 // DownloadBundle downloads the client bundle from MKE to local storage.
 func DownloadBundle(config *api.ClusterConfig) error {
+	if config.Spec.MKE == nil {
+		return errNoMKE
+	}
+
 	if len(config.Spec.Managers()) == 0 {
 		return errNoManagersInConfig
 	}

--- a/pkg/product/mke/describe.go
+++ b/pkg/product/mke/describe.go
@@ -39,7 +39,7 @@ func (p *MKE) Describe(reportName string) error {
 		&de.DetectOS{},
 		&de.GatherFacts{},
 		&common.Disconnect{},
-		&de.Describe{MKE: mke, MSR: msr},
+		&de.Describe{MKE: mke, MSR2: msr},
 	)
 
 	if err := phaseManager.Run(); err != nil {

--- a/pkg/product/mke/phase/authenticate_docker.go
+++ b/pkg/product/mke/phase/authenticate_docker.go
@@ -14,7 +14,7 @@ type AuthenticateDocker struct {
 	phase.BasicPhase
 }
 
-// ShouldRun is true when registry credentials are set.
+// ShouldRun is true when registry credentials are set and MKE is included.
 func (p *AuthenticateDocker) ShouldRun() bool {
 	if p.Config.Spec.MKE == nil {
 		return false

--- a/pkg/product/mke/phase/describe.go
+++ b/pkg/product/mke/phase/describe.go
@@ -14,8 +14,8 @@ import (
 type Describe struct {
 	phase.BasicPhase
 
-	MKE bool
-	MSR bool
+	MKE  bool
+	MSR2 bool
 }
 
 // Title for the phase.
@@ -28,8 +28,8 @@ func (p *Describe) Run() error {
 	switch {
 	case p.MKE:
 		p.mkeReport()
-	case p.MSR:
-		p.msrReport()
+	case p.MSR2:
+		p.msr2Reports()
 	default:
 		p.hostReport()
 	}
@@ -38,6 +38,10 @@ func (p *Describe) Run() error {
 }
 
 func (p *Describe) mkeReport() {
+	if p.Config.Spec.MKE == nil {
+		fmt.Println("No MKE installation")
+		return
+	}
 	if !p.Config.Spec.MKE.Metadata.Installed {
 		fmt.Println("Not installed")
 		return
@@ -61,7 +65,11 @@ func (p *Describe) mkeReport() {
 	tabWriter.Flush()
 }
 
-func (p *Describe) msrReport() {
+func (p *Describe) msr2Reports() {
+	if p.Config.Spec.MSR2 == nil {
+		fmt.Println("No MSR2 installation")
+		return
+	}
 	// Configure the columns to start.
 	tabWriter := new(tabwriter.Writer)
 	// minwidth, tabwidth, padding, padchar, flags

--- a/pkg/product/mke/phase/info.go
+++ b/pkg/product/mke/phase/info.go
@@ -16,6 +16,11 @@ func (p *Info) Title() string {
 	return "Cluster info"
 }
 
+// ShouldRun is true when MKE is included.
+func (p *Info) ShouldRun() bool {
+	return p.Config.Spec.MKE != nil
+}
+
 // Run ...
 func (p *Info) Run() error {
 	log.Info("Cluster is now configured.")

--- a/pkg/product/mke/phase/install_msr2.go
+++ b/pkg/product/mke/phase/install_msr2.go
@@ -30,6 +30,9 @@ func (p *InstallMSR2) Title() string {
 // ShouldRun should return true only when there is an installation to be
 // performed.
 func (p *InstallMSR2) ShouldRun() bool {
+	if !p.Config.Spec.ContainsMSR2() {
+		return false
+	}
 	p.leader = p.Config.Spec.MSR2Leader()
 	return p.Config.Spec.ContainsMSR2() && (p.leader.MSR2Metadata == nil || !p.leader.MSR2Metadata.Installed)
 }

--- a/pkg/product/mke/phase/join_msr2_replicas.go
+++ b/pkg/product/mke/phase/join_msr2_replicas.go
@@ -47,6 +47,11 @@ func (p *JoinMSR2Replicas) Title() string {
 	return "Join MSR2 Replicas"
 }
 
+// ShouldRun should return true only when there is a configured installation.
+func (p *JoinMSR2Replicas) ShouldRun() bool {
+	return p.Config.Spec.ContainsMSR2()
+}
+
 // Run joins all the workers nodes to swarm if not already part of it.
 func (p *JoinMSR2Replicas) Run() error {
 	msrLeader := p.Config.Spec.MSR2Leader()

--- a/pkg/product/mke/phase/label_nodes.go
+++ b/pkg/product/mke/phase/label_nodes.go
@@ -23,6 +23,11 @@ func (p *LabelNodes) Title() string {
 	return "Label nodes"
 }
 
+// ShouldRun is true when MKE is included.
+func (p *LabelNodes) ShouldRun() bool {
+	return p.Config.Spec.MKE != nil
+}
+
 // Run labels all nodes with launchpad label.
 func (p *LabelNodes) Run() error {
 	swarmLeader := p.Config.Spec.SwarmLeader()

--- a/pkg/product/mke/phase/uninstall_msr2.go
+++ b/pkg/product/mke/phase/uninstall_msr2.go
@@ -9,19 +9,24 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// UninstallMSR is the phase implementation for running MSR uninstall.
-type UninstallMSR struct {
+// UninstallMSR2 is the phase implementation for running MSR uninstall.
+type UninstallMSR2 struct {
 	phase.Analytics
 	phase.BasicPhase
 }
 
 // Title prints the phase title.
-func (p *UninstallMSR) Title() string {
+func (p *UninstallMSR2) Title() string {
 	return "Uninstall MSR2 components"
 }
 
+// ShouldRun should return true only when there is a configured installation.
+func (p *UninstallMSR2) ShouldRun() bool {
+	return p.Config.Spec.ContainsMSR2()
+}
+
 // Run an uninstall via msr.Cleanup.
-func (p *UninstallMSR) Run() error {
+func (p *UninstallMSR2) Run() error {
 	swarmLeader := p.Config.Spec.SwarmLeader()
 	msrLeader := p.Config.Spec.MSR2Leader()
 	if msrLeader == nil || !msrLeader.MSR2Metadata.Installed {

--- a/pkg/product/mke/phase/upgrade_msr2.go
+++ b/pkg/product/mke/phase/upgrade_msr2.go
@@ -35,6 +35,9 @@ func (p *UpgradeMSR2) Title() string {
 
 // ShouldRun should return true only when there is an upgrade to be performed.
 func (p *UpgradeMSR2) ShouldRun() bool {
+	if !p.Config.Spec.ContainsMSR2() {
+		return false
+	}
 	h := p.Config.Spec.MSR2Leader()
 	return p.Config.Spec.ContainsMSR() && h.MSR2Metadata != nil && h.MSR2Metadata.InstalledVersion != p.Config.Spec.MSR2.Version
 }

--- a/pkg/product/mke/reset.go
+++ b/pkg/product/mke/reset.go
@@ -22,7 +22,7 @@ func (p *MKE) Reset() error {
 
 	// begin MSR phases
 	if p.ClusterConfig.Spec.ContainsMSR2() {
-		phaseManager.AddPhase(&mke.UninstallMSR{})
+		phaseManager.AddPhase(&mke.UninstallMSR2{})
 	} else if p.ClusterConfig.Spec.ContainsMSR3() {
 		phaseManager.AddPhase(&mke.UninstallMSR3{})
 	}


### PR DESCRIPTION
- docker authentication relies on MKE configuration, so it can only happen if MKE is going to be installed.
- more checking of config before running MKE/MSR functionality
- some renaming MSR->MSR2 of steps, variables