### PR TITLE
PRODENG-2719 prepare_hosts msr2 panic regression fix

### DIFF
--- a/pkg/product/mke/phase/prepare_host.go
+++ b/pkg/product/mke/phase/prepare_host.go
@@ -43,7 +43,7 @@ func (p *PrepareHost) Run() error {
 		return fmt.Errorf("failed to authorize docker: %w", err)
 	}
 
-	if p.Config.Spec.ContainsMSR() && p.Config.Spec.MSR2.ReplicaIDs == "sequential" {
+	if p.Config.Spec.ContainsMSR2() && p.Config.Spec.MSR2.ReplicaIDs == "sequential" {
 		err = msr2.AssignSequentialReplicaIDs(p.Config)
 		if err != nil {
 			return fmt.Errorf("failed to assign sequential MSR replica IDs: %w", err)


### PR DESCRIPTION
- regressed during msr3 config refactor.
- simple switch to checking for msr2 when doing msr2 things to avoid having msr3 instigate msr2 things.