### PR TITLE
PRODENG-2718 update copyright year (#507)

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -88,7 +88,7 @@ func NewApplyCommand() *cli.Command {
 				if !ctx.Bool("disable-logo") {
 					os.Stdout.WriteString(logo.Logo)
 				}
-				fmt.Fprintf(os.Stdout, "   Mirantis Launchpad (c) 2022 Mirantis, Inc.                          %s\n\n", version.Version)
+				fmt.Fprintf(os.Stdout, "   Mirantis Launchpad (c) 2024 Mirantis, Inc.                          %s\n\n", version.Version)
 			}
 
 			err = product.Apply(ctx.Bool("disable-cleanup"), ctx.Bool("force"), ctx.Int("concurrency"), ctx.Bool("force-upgrade"))

--- a/pkg/mke/mke.go
+++ b/pkg/mke/mke.go
@@ -294,7 +294,7 @@ func writeBundle(bundleDir string, bundle *zip.Reader) error {
 		if err != nil {
 			return fmt.Errorf("error while reading file %s: %w", zipFile.Name, err)
 		}
-		mode := int32(0o644)
+		mode := uint32(0o644)
 		if strings.Contains(zipFile.Name, "key.pem") {
 			mode = 0o600
 		}

--- a/pkg/product/mke/api/host.go
+++ b/pkg/product/mke/api/host.go
@@ -230,8 +230,9 @@ func (h *Host) WriteFileLarge(src, dst string) error {
 		return fmt.Errorf("failed to stat file: %w", err)
 	}
 	size := stat.Size()
+	usize := uint64(size) //nolint: gosec
 
-	log.Infof("%s: uploading %s to %s", h, byteutil.FormatBytes(uint64(stat.Size())), dst)
+	log.Infof("%s: uploading %s to %s", h, byteutil.FormatBytes(usize), dst)
 
 	if err := h.Connection.Upload(src, dst); err != nil {
 		return fmt.Errorf("upload failed: %w", err)
@@ -239,7 +240,7 @@ func (h *Host) WriteFileLarge(src, dst string) error {
 
 	duration := time.Since(startTime).Seconds()
 	speed := float64(size) / duration
-	log.Infof("%s: transferred %s in %.1f seconds (%s/s)", h, byteutil.FormatBytes(uint64(size)), duration, byteutil.FormatBytes(uint64(speed)))
+	log.Infof("%s: transferred %s in %.1f seconds (%s/s)", h, byteutil.FormatBytes(usize), duration, byteutil.FormatBytes(uint64(speed)))
 
 	return nil
 }

--- a/pkg/product/mke/phase/upload_images.go
+++ b/pkg/product/mke/phase/upload_images.go
@@ -51,7 +51,8 @@ func (p *LoadImages) HostFilterFunc(h *api.Host) bool {
 		h.Metadata.ImagesToUpload = append(h.Metadata.ImagesToUpload, imagePath)
 		info, err := entry.Info()
 		if err == nil {
-			h.Metadata.TotalImageBytes += uint64(info.Size())
+			usize := uint64(info.Size()) //nolint: gosec
+			h.Metadata.TotalImageBytes += usize
 		}
 	}
 


### PR DESCRIPTION
* PRODENG-2718 update copyright year

- updated copyright year string in apply command (the only place I could find it)

* PRODENG-2718 new linting failures

- int64->uint64 conversions can't be fixed, had to be escaped. File size can neven be negative so the issue is a false positive.