### PR TITLE
PRODENG-2744 Custom path for installer.sh script in remote hosts

### DIFF
--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -33,10 +33,21 @@ func (c LinuxConfigurer) MCRConfigPath() string {
 
 // InstallMCR install MCR on Linux.
 func (c LinuxConfigurer) InstallMCR(h os.Host, scriptPath string, engineConfig common.MCRConfig) error {
-	pwd := c.riglinux.Pwd(h)
 	base := path.Base(scriptPath)
-	installer := pwd + "/" + base
-	err := h.Upload(scriptPath, installer)
+
+	installScriptDir := engineConfig.InstallScriptRemoteDirLinux
+	if installScriptDir == "" {
+		installScriptDir = c.riglinux.Pwd(h)
+	}
+
+	_, err := h.ExecOutput(fmt.Sprintf("mkdir -p %s", installScriptDir))
+	if err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", installScriptDir, err)
+	}
+
+	installer := path.Join(installScriptDir, base)
+
+	err = h.Upload(scriptPath, installer)
 	if err != nil {
 		log.Errorf("failed: %s", err.Error())
 		return fmt.Errorf("upload %s to %s: %w", scriptPath, installer, err)

--- a/pkg/product/common/api/mcr_config.go
+++ b/pkg/product/common/api/mcr_config.go
@@ -19,15 +19,16 @@ type DockerDaemonConfig struct {
 
 // MCRConfig holds the Mirantis Container Runtime installation specific options.
 type MCRConfig struct {
-	Version             string   `yaml:"version"`
-	RepoURL             string   `yaml:"repoURL,omitempty"`
-	InstallURLLinux     string   `yaml:"installURLLinux,omitempty"`
-	InstallURLWindows   string   `yaml:"installURLWindows,omitempty"`
-	Channel             string   `yaml:"channel,omitempty"`
-	Prune               bool     `yaml:"prune,omitempty"`
-	ForceUpgrade        bool     `yaml:"forceUpgrade,omitempty"`
-	SwarmInstallFlags   Flags    `yaml:"swarmInstallFlags,omitempty,flow"`
-	SwarmUpdateCommands []string `yaml:"swarmUpdateCommands,omitempty,flow"`
+	Version                     string   `yaml:"version"`
+	RepoURL                     string   `yaml:"repoURL,omitempty"`
+	InstallURLLinux             string   `yaml:"installURLLinux,omitempty"`
+	InstallScriptRemoteDirLinux string   `yaml:"installScriptRemoteDirLinux,omitempty"`
+	InstallURLWindows           string   `yaml:"installURLWindows,omitempty"`
+	Channel                     string   `yaml:"channel,omitempty"`
+	Prune                       bool     `yaml:"prune,omitempty"`
+	ForceUpgrade                bool     `yaml:"forceUpgrade,omitempty"`
+	SwarmInstallFlags           Flags    `yaml:"swarmInstallFlags,omitempty,flow"`
+	SwarmUpdateCommands         []string `yaml:"swarmUpdateCommands,omitempty,flow"`
 
 	Metadata *MCRMetadata `yaml:"-"`
 }


### PR DESCRIPTION
- hosts can have a path defined for where the MCR installer should be stored on the machine. This makes it easier to whitelist the sudo for running the installer.