### PR TITLE
PRODENG-3148 install mcr license

### DIFF
--- a/pkg/docker/envauth.go
+++ b/pkg/docker/envauth.go
@@ -22,10 +22,10 @@ func DiscoverEnvLogin(prefixes []string) (user, pass string, err error) {
 			if pass == "" {
 				err = fmt.Errorf("%w; %s username env variable did not have matching password variable %s", ErrMissingPassword, userEnv, passEnv)
 			}
-			return
+			return user, pass, err
 		}
 	}
 	// if there were no matching vars, then we are not supposed to do a login
 	err = ErrNoEnvPasswordsFound
-	return
+	return user, pass, err
 }

--- a/pkg/product/common/api/mcr_config.go
+++ b/pkg/product/common/api/mcr_config.go
@@ -39,6 +39,7 @@ type MCRConfig struct {
 	RepoURL                     string   `yaml:"repoURL,omitempty"`
 	AdditionalRuntimes          string   `yaml:"additionalRuntimes,omitempty"`
 	DefaultRuntime              string   `yaml:"defaultRuntime,omitempty"`
+	License                     string   `yaml:"license"`
 	InstallURLLinux             string   `yaml:"installURLLinux,omitempty"`
 	InstallScriptRemoteDirLinux string   `yaml:"installScriptRemoteDirLinux,omitempty"`
 	InstallURLWindows           string   `yaml:"installURLWindows,omitempty"`

--- a/pkg/product/common/api/mcr_config.go
+++ b/pkg/product/common/api/mcr_config.go
@@ -141,7 +141,7 @@ func processVersionChannelMatch(config *MCRConfig) error {
 func processVersionIsAVersion(config *MCRConfig) (ver *version.Version, err error) {
 	if config.Version == "" {
 		err = ErrInvalidVersion
-		return
+		return ver, err
 	}
 
 	defer func() {
@@ -152,5 +152,5 @@ func processVersionIsAVersion(config *MCRConfig) (ver *version.Version, err erro
 	}()
 
 	ver, err = version.NewVersion(config.Version)
-	return
+	return ver, err //nolint:wrapcheck
 }

--- a/pkg/product/mke/api/configurer.go
+++ b/pkg/product/mke/api/configurer.go
@@ -20,6 +20,7 @@ type HostConfigurer interface {
 	UpdateEnvironment(os.Host, map[string]string) error
 	CleanupEnvironment(os.Host, map[string]string) error
 	MCRConfigPath() string
+	InstallMCRLicense(os.Host, string) error
 	InstallMCR(os.Host, string, common.MCRConfig) error
 	UninstallMCR(os.Host, string, common.MCRConfig) error
 	DockerCommandf(template string, args ...any) string

--- a/pkg/product/mke/apply.go
+++ b/pkg/product/mke/apply.go
@@ -32,6 +32,7 @@ func (p *MKE) Apply(disableCleanup, force bool, concurrency int, forceUpgrade bo
 		&mke.ConfigureMCR{},
 		&mke.InstallMCR{},
 		&mke.UpgradeMCR{Concurrency: concurrency, ForceUpgrade: forceUpgrade},
+		&mke.InstallMCRLicense{},
 		&mke.RestartMCR{},
 		&mke.LoadImages{},
 		&mke.AuthenticateDocker{},

--- a/pkg/product/mke/phase/install_mcr_license.go
+++ b/pkg/product/mke/phase/install_mcr_license.go
@@ -1,0 +1,43 @@
+package phase
+
+import (
+	"fmt"
+
+	"github.com/Mirantis/launchpad/pkg/phase"
+	"github.com/Mirantis/launchpad/pkg/product/mke/api"
+	log "github.com/sirupsen/logrus"
+)
+
+// InstallMCRLicense phase implementation.
+type InstallMCRLicense struct {
+	phase.Analytics
+	phase.HostSelectPhase
+}
+
+// ShouldRun if a license is provided, we should run this phase.
+func (p *InstallMCRLicense) ShouldRun() bool {
+	return p.Config.Spec.MCR.License != ""
+}
+
+// Title for the phase.
+func (p *InstallMCRLicense) Title() string {
+	return "Install Mirantis Container Runtime License"
+}
+
+// Run installs the engine on each host.
+func (p *InstallMCRLicense) Run() error {
+	if err := p.Hosts.ParallelEach(p.installMCRLicense); err != nil {
+		return fmt.Errorf("failed to install MCR license: %w", err)
+	}
+	return nil
+}
+
+func (p *InstallMCRLicense) installMCRLicense(h *api.Host) error {
+	log.Infof("%s: installing MCR license", h)
+	if err := h.Configurer.InstallMCRLicense(h, p.Config.Spec.MCR.License); err != nil {
+		log.Errorf("%s: failed to install MCR License: %s", h, err.Error())
+		return fmt.Errorf("%s: failed to install MCR License: %w", h, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- new mcr config string for license
- apply command runs new install license phase
- new install license phase
- configurer interface now has a function for installing license
- linux and windows implement the install license function

ALSO:

- some golangci-lint linting.

NOTE:

- currently install license after MCR is installed, so that we can detect the docker root
- currently don't uninstall the license