### PR TITLE
PRODENG-3392: run PR & smoke workflows on self-hosted runners

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,7 @@ on:
       - go.mod
       - go.sum
       - Makefile
+      - '.github/workflows/go.yml'
 
 jobs:
   unit-test:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   lint:
     name: Lint Code
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set-mirantis-public
     env:
       GOTOOLCHAIN: auto
 

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   smoke-modern:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set-mirantis-public
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'smoke-test') ||
@@ -27,8 +27,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Run modern smoke test
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -36,7 +43,7 @@ jobs:
         run: make smoke-modern
 
   smoke-legacy:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set-mirantis-public
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'smoke-test') ||
@@ -44,8 +51,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Run legacy smoke test
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -53,7 +67,7 @@ jobs:
         run: make smoke-legacy
 
   smoke-windows:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set-mirantis-public
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'smoke-test') ||
@@ -61,8 +75,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Run windows smoke test
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -70,7 +91,7 @@ jobs:
         run: make smoke-windows
 
   smoke-upgrade:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set-mirantis-public
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'smoke-test') ||
@@ -78,8 +99,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Run upgrade smoke test
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   smoke-modern:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set-mirantis-public
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'smoke-test') ||
@@ -36,7 +36,7 @@ jobs:
         run: make smoke-modern
 
   smoke-legacy:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set-mirantis-public
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'smoke-test') ||
@@ -53,7 +53,7 @@ jobs:
         run: make smoke-legacy
 
   smoke-windows:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set-mirantis-public
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'smoke-test') ||
@@ -70,7 +70,7 @@ jobs:
         run: make smoke-windows
 
   smoke-upgrade:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set-mirantis-public
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'smoke-test') ||


### PR DESCRIPTION
## Summary

Move PR validation and smoke tests off GitHub-hosted `ubuntu-latest` onto the internal self-hosted runner set `arc-runner-set-mirantis-public`.

## Changes

### `.github/workflows/pr.yml`
- `lint` job → `arc-runner-set-mirantis-public`. (`unit-test`, `integration-test`, and `security-scan` remain on `ubuntu-latest` for now.)

### `.github/workflows/smoke-tests.yaml`
All four smoke jobs (`smoke-modern`, `smoke-legacy`, `smoke-windows`, `smoke-upgrade`) → `arc-runner-set-mirantis-public`. The self-hosted runner image lacks two things the tests need, so this workflow also:

1. **Installs Go before `make smoke-*`.** The runner image ships without Go, so `go test` under `make smoke-*` fails with `make: go: No such file or directory`. Added `actions/setup-go@v6` (`go-version-file: go.mod`, `cache: true`) after checkout in every smoke job.

2. **Disables the `hashicorp/setup-terraform` Node wrapper** (`terraform_wrapper: false`). With the wrapper on (default), terratest's `defaultTerraformExecutable()` probes `terraform -version` with nil stdio at package init; the Node wrapper exits non-zero on this runner image, so terratest falls back to `tofu` (see [terratest cmd.go](https://github.com/gruntwork-io/terratest/blob/v0.56.0/modules/terraform/cmd.go)). `tofu` is not installed, and every test fails within seconds with:
   ```
   exec: "tofu": executable file not found in $PATH
   ```
   Turning the wrapper off makes setup-terraform lay down the raw `terraform` binary, the probe succeeds, and terratest picks `terraform` — matching `main`-branch behaviour on `ubuntu-latest`.

### `.github/workflows/go.yml`
- Scope the pull_request `paths` filter to include `.github/workflows/go.yml` itself so changes to this workflow retrigger its own checks (mirrors the existing pattern in `pr.yml`).

## Verification

Latest smoke-tests run against `arc-runner-set-mirantis-public` (before squash, HEAD `c2355c6` — same tree as this commit):

| Job | Result |
| --- | --- |
| `smoke-modern`  | ✅ pass |
| `smoke-legacy`  | ✅ pass |
| `smoke-upgrade` | ✅ pass |
| `smoke-windows` | ❌ fail — WinRM 5986 timeout during Connect/Reset. **Also fails on `main` with the identical signature** ([run 26822741859](https://github.com/Mirantis/launchpad/actions/runs/26822741859)). Unrelated to the runner migration; separate ticket. |

`lint` on `arc-runner-set-mirantis-public` was already green pre-squash.

---
_Created by AI_
