### PR TITLE
PRODENG-3471: fix Windows MCR install for FIPS channels

### DIFF
--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -60,7 +60,7 @@ func (c WindowsConfigurer) InstallMCRLicense(h os.Host, lic string) error {
 
 // InstallMCR install MCR on Windows.
 func (c WindowsConfigurer) InstallMCR(h os.Host, engineConfig commonconfig.MCRConfig) error {
-	version := "latest"
+	version := windowsInstallerVersion(engineConfig.Channel)
 
 	installerPath, getInstallerErr := GetInstaller(engineConfig.InstallURLWindows)
 	if getInstallerErr != nil {
@@ -122,6 +122,25 @@ func (c WindowsConfigurer) InstallMCR(h os.Host, engineConfig commonconfig.MCRCo
 // code 3010 (ERROR_SUCCESS_REBOOT_REQUIRED).
 func isExitCode3010(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "non-zero exit code: 3010")
+}
+
+// windowsInstallerVersion returns the version token to pass as DOCKER_VERSION
+// to install.ps1. For non-FIPS channels the repo publishes only
+// docker-latest.zip so "latest" is correct. For FIPS channels (suffix /fips)
+// the repo publishes docker-<version>+fips.zip but no docker-latest+fips.zip,
+// so the version must be extracted from the channel string.
+func windowsInstallerVersion(channel string) string {
+	if !strings.HasSuffix(channel, "/fips") {
+		return "latest"
+	}
+	ch := strings.TrimSuffix(channel, "/fips")
+	parts := strings.Split(ch, "-")
+	for i, p := range parts {
+		if len(p) > 0 && p[0] >= '0' && p[0] <= '9' {
+			return strings.Join(parts[i:], "-")
+		}
+	}
+	return "latest"
 }
 
 // Reboot triggers an immediate forced restart by scheduling a SYSTEM-context

--- a/pkg/configurer/windows_test.go
+++ b/pkg/configurer/windows_test.go
@@ -1,0 +1,32 @@
+package configurer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindowsInstallerVersion(t *testing.T) {
+	tests := []struct {
+		channel string
+		want    string
+	}{
+		// Standard channels — always "latest"; docker-latest.zip is published
+		{"stable-29.2", "latest"},
+		{"stable-25.0", "latest"},
+		{"ee-stable-29.2", "latest"},
+		// FIPS channels — version extracted; only docker-<version>+fips.zip is published
+		{"stable-29.2.1/fips", "29.2.1"},
+		{"stable-29.4.1/fips", "29.4.1"},
+		{"test-29.4.1/fips", "29.4.1"},
+		// FIPS RC channel
+		{"test-29.4.1-rc3/fips", "29.4.1-rc3"},
+		// FIPS channel with no parseable version — falls back to latest
+		{"stable/fips", "latest"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.channel, func(t *testing.T) {
+			require.Equal(t, tt.want, windowsInstallerVersion(tt.channel), "channel=%q", tt.channel)
+		})
+	}
+}


### PR DESCRIPTION
Jira: https://mirantis.jira.com/browse/PRODENG-3471

> **Draft** — pending confirmation from the MCR release team on whether `docker-latest+fips.zip` is an intentional omission or a publishing gap. See Jira comment for the full analysis. If MCR adds the alias this PR becomes unnecessary; if FIPS policy requires pinned versions only, this fix is the right approach.

## Problem

For FIPS channels (e.g. `stable-29.2.1/fips`) the Windows MCR installer repo publishes versioned artifacts (`docker-29.2.1+fips.zip`) but does **not** publish `docker-latest+fips.zip`. Launchpad hardcodes `DOCKER_VERSION=latest`, causing `install.ps1` to construct a non-existent URL and exit 1 on all Windows nodes. Linux nodes are unaffected (they use the package manager, not this URL).

## Fix

`MCRConfig.WindowsInstallerVersion()` returns `"latest"` for all non-FIPS channels (preserving existing behaviour) and extracts the version from the channel string for FIPS channels:

- `stable-29.2.1/fips` → `29.2.1`
- `test-29.4.1-rc3/fips` → `29.4.1-rc3`
- `stable-29.2` → `latest` (unchanged)

`InstallMCR` in `windows.go` uses this instead of the hardcoded `"latest"`.

## Changes

- `pkg/product/common/config/mcr_config.go` — `WindowsInstallerVersion()` method
- `pkg/product/common/config/mcr_config_test.go` — 8 table-driven test cases
- `pkg/configurer/windows.go` — use `WindowsInstallerVersion()` instead of `"latest"`

## Note on design

The method name and the FIPS-only guard are a design choice made before the MCR publishing question was fully explored. The approach may change based on the MCR team's response.