### PR TITLE
smoke: add TestCuttingEdgeCluster (rhel10/rocky10/ubuntu24/sles15)

### DIFF
--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -66,6 +66,12 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: make smoke-legacy
 
+  # Bleeding-edge platforms (rhel10/rocky10). MCR package availability for
+  # these platforms lags their AMI/repo-metadata availability -- this job is
+  # intentionally merged ahead of full support so it goes green automatically,
+  # with no further workflow changes, once repos.mirantis.com publishes
+  # docker-ee for rhel/10 and rocky/10. Label-gated rather than always-on
+  # while that support is pending.
   smoke-cutting-edge:
     runs-on: ubuntu-latest
     if: |

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -66,6 +66,23 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: make smoke-legacy
 
+  smoke-cutting-edge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'smoke-test') ||
+      contains(github.event.pull_request.labels.*.name, 'smoke-cutting-edge')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+      - name: Run cutting-edge smoke test
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: make smoke-cutting-edge
+
   smoke-windows:
     runs-on: arc-runner-set-mirantis-public
     if: |

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,12 @@ functional-test:
 integration-test:
 	go test -v ./test/integration/... -timeout 20m
 
+# Targets bleeding-edge platforms (rhel10/rocky10) via TestCuttingEdgeCluster.
+# MCR package availability for these platforms lags their AMI/repo-metadata
+# availability -- this target (and its CI job) is intentionally merged ahead
+# of full support so it goes green automatically, with no further code
+# changes, the moment repos.mirantis.com publishes docker-ee for rhel/10 and
+# rocky/10. Run manually or via the smoke-cutting-edge label to check status.
 .PHONY: smoke-cutting-edge
 smoke-cutting-edge:
 	go test -count=1 -v ./test/smoke/... -run TestCuttingEdgeCluster -timeout 50m

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ functional-test:
 integration-test:
 	go test -v ./test/integration/... -timeout 20m
 
+.PHONY: smoke-cutting-edge
+smoke-cutting-edge:
+	go test -count=1 -v ./test/smoke/... -run TestCuttingEdgeCluster -timeout 50m
+
 .PHONY: smoke-modern
 smoke-modern:
 	go test -count=1 -v ./test/smoke/... -run TestModernCluster -timeout 50m

--- a/examples/terraform/aws-simple/platform.tf
+++ b/examples/terraform/aws-simple/platform.tf
@@ -44,6 +44,7 @@ locals {
 module "platform" {
   count  = length(local.upstream_platform_keys)
   source = "terraform-mirantis-modules/provision-aws/mirantis//modules/platform"
+  version = ">= 0.1.7"
 
   platform_key     = local.upstream_platform_keys[count.index]
   windows_password = var.windows_password

--- a/examples/terraform/aws-simple/provision.tf
+++ b/examples/terraform/aws-simple/provision.tf
@@ -7,6 +7,7 @@ locals {
 # PROVISION MACHINES/NETWORK
 module "provision" {
   source = "terraform-mirantis-modules/provision-aws/mirantis"
+  version = ">= 0.1.7"
 
   name        = var.name
   common_tags = local.tags

--- a/test/platforms.go
+++ b/test/platforms.go
@@ -117,6 +117,20 @@ var Platforms = map[string]Platform{
 		Public:     true,
 		UserData:   "sudo firewall-cmd --permanent --add-port=2377/tcp --add-port=7946/tcp --add-port=7946/udp --add-port=4789/udp --add-port=10250/tcp; sudo firewall-cmd --reload",
 	},
+	"Rocky10": {
+		Name:       "rocky_10",
+		Count:      1,
+		VolumeSize: "100",
+		Public:     true,
+		UserData:   "sudo firewall-cmd --permanent --add-port=2377/tcp --add-port=7946/tcp --add-port=7946/udp --add-port=4789/udp --add-port=10250/tcp; sudo firewall-cmd --reload",
+	},
+	"Rhel10": {
+		Name:       "rhel_10",
+		Count:      1,
+		VolumeSize: "100",
+		Public:     true,
+		UserData:   "sudo firewall-cmd --permanent --add-port=2377/tcp --add-port=7946/tcp --add-port=7946/udp --add-port=4789/udp --add-port=10250/tcp; sudo firewall-cmd --reload",
+	},
 	"Windows2019": {
 		Name:       "windows_2019",
 		Count:      1,

--- a/test/platforms.go
+++ b/test/platforms.go
@@ -103,6 +103,13 @@ var Platforms = map[string]Platform{
 		Public:     true,
 		UserData:   "sudo firewall-cmd --permanent --add-port=2377/tcp --add-port=7946/tcp --add-port=7946/udp --add-port=4789/udp --add-port=10250/tcp; sudo firewall-cmd --reload",
 	},
+	"Sles16": {
+		Name:       "sles_16",
+		Count:      1,
+		VolumeSize: "100",
+		Public:     true,
+		UserData:   "sudo firewall-cmd --permanent --add-port=2377/tcp --add-port=7946/tcp --add-port=7946/udp --add-port=4789/udp --add-port=10250/tcp; sudo firewall-cmd --reload",
+	},
 	"Rocky8": {
 		Name:       "rocky_8",
 		Count:      1,
@@ -167,4 +174,3 @@ var Platforms = map[string]Platform{
 		UserData:   "sudo ufw allow 2377,7946,10250/tcp; sudo ufw allow 7946,4789/udp",
 	},
 }
-

--- a/test/platforms.go
+++ b/test/platforms.go
@@ -159,6 +159,13 @@ var Platforms = map[string]Platform{
 		Public:     true,
 		UserData:   "sudo ufw allow 2377,7946,10250/tcp; sudo ufw allow 7946,4789/udp",
 	},
+	"Ubuntu26": {
+		Name:       "ubuntu_26.04",
+		Count:      1,
+		VolumeSize: "100",
+		Public:     true,
+		UserData:   "sudo ufw allow 2377,7946,10250/tcp; sudo ufw allow 7946,4789/udp",
+	},
 	"Windows2025": {
 		Name:       "windows_2025",
 		Count:      1,

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -112,7 +112,7 @@ func runSmokeTest(t *testing.T, cfg smokeConfig) {
 		"nodegroups":        cfg.Nodegroups,
 		"ssh_key_algorithm": cfg.SSHKeyAlgorithm,
 		"extra_tags": map[string]string{
-			"launchpad-smoke-test": "true",
+			"launchpad-smoke-test":      "true",
 			"launchpad-smoke-test-name": cfg.Name,
 		},
 	}
@@ -193,11 +193,15 @@ func TestModernCluster(t *testing.T) {
 
 // TestCuttingEdgeCluster exercises rhel10/rocky10/ubuntu24 managers and workers
 // with sles15 as an additional worker, using the latest MCR and MKE versions.
-// Requires terraform-mirantis-modules/terraform-mirantis-provision-aws PR #22 (rhel_10/rocky_10
-// platform keys) to be merged and the module version bumped before this test can run.
+// The rhel_10/rocky_10 platform keys are available in
+// terraform-mirantis-provision-aws >= v0.1.7 (pinned in examples/terraform/aws-simple).
 func TestCuttingEdgeCluster(t *testing.T) {
 	runSmokeTest(t, smokeConfig{
-		Name:            "cutting-edge",
+		// AWS LB/target-group names are capped at 32 chars: the stack name is
+		// "smoke-{Name}-{5-char-random}" and Terraform appends suffixes like
+		// "-mke-kube" (9 chars), capping len(Name) at 11. Hence "cuttingedge"
+		// rather than "cutting-edge" (12 chars).
+		Name:            "cuttingedge",
 		MCRChannel:      "stable-29.4",
 		MKEVersion:      "3.9.2",
 		MSRVersion:      "3.1.18",

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -191,15 +191,19 @@ func TestModernCluster(t *testing.T) {
 	})
 }
 
-// TestCuttingEdgeCluster exercises rhel10/rocky10/ubuntu24 managers and workers
+// TestCuttingEdgeCluster exercises rhel10/rocky10/ubuntu26 managers and workers
 // with sles16 as an additional worker, using the latest MCR and MKE versions.
 // The rhel_10/rocky_10 platform keys are available in
 // terraform-mirantis-provision-aws >= v0.1.7 (pinned in examples/terraform/aws-simple).
 //
-// NOTE: as of 2026-07-22, MCR has not published Docker EE packages for SLES 16
-// (repos.mirantis.com/sles/ only has 12/12.3/15 - no 16 directory). This node
-// is expected to fail at the Install MCR phase until MCR ships SLES 16 support;
-// see also the RHEL10/Rocky10 MCR-daemon-start gap tracked separately.
+// NOTE: as of 2026-07-22, MCR has not published Docker EE packages for either
+// SLES 16 (repos.mirantis.com/sles/ only has 12/12.3/15 - no 16 directory) or
+// Ubuntu 26.04 "resolute" (repos.mirantis.com/ubuntu/dists/ only has
+// trusty/xenial/bionic/focal/jammy/noble - no resolute directory). Both nodes
+// are expected to fail at the Install MCR phase until MCR ships support; see
+// also the RHEL10/Rocky10 MCR-daemon-start gap (missing xt_* kernel modules
+// break iptables, and MCR's nftables backend is incompatible with swarm mode)
+// tracked separately.
 func TestCuttingEdgeCluster(t *testing.T) {
 	runSmokeTest(t, smokeConfig{
 		// AWS LB/target-group names are capped at 32 chars: the stack name is
@@ -214,11 +218,11 @@ func TestCuttingEdgeCluster(t *testing.T) {
 		Nodegroups: map[string]interface{}{
 			"MngrRhel10":   test.Platforms["Rhel10"].GetManager(),
 			"MngrRocky10":  test.Platforms["Rocky10"].GetManager(),
-			"MngrUbuntu24": test.Platforms["Ubuntu24"].GetManager(),
+			"MngrUbuntu26": test.Platforms["Ubuntu26"].GetManager(),
 			"WrkRhel10":    test.Platforms["Rhel10"].GetWorker(),
 			"WrkRocky10":   test.Platforms["Rocky10"].GetWorker(),
 			"WrkSles16":    test.Platforms["Sles16"].GetWorker(),
-			"WrkUbuntu24":  test.Platforms["Ubuntu24"].GetWorker(),
+			"WrkUbuntu26":  test.Platforms["Ubuntu26"].GetWorker(),
 		},
 	})
 }

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -192,9 +192,14 @@ func TestModernCluster(t *testing.T) {
 }
 
 // TestCuttingEdgeCluster exercises rhel10/rocky10/ubuntu24 managers and workers
-// with sles15 as an additional worker, using the latest MCR and MKE versions.
+// with sles16 as an additional worker, using the latest MCR and MKE versions.
 // The rhel_10/rocky_10 platform keys are available in
 // terraform-mirantis-provision-aws >= v0.1.7 (pinned in examples/terraform/aws-simple).
+//
+// NOTE: as of 2026-07-22, MCR has not published Docker EE packages for SLES 16
+// (repos.mirantis.com/sles/ only has 12/12.3/15 - no 16 directory). This node
+// is expected to fail at the Install MCR phase until MCR ships SLES 16 support;
+// see also the RHEL10/Rocky10 MCR-daemon-start gap tracked separately.
 func TestCuttingEdgeCluster(t *testing.T) {
 	runSmokeTest(t, smokeConfig{
 		// AWS LB/target-group names are capped at 32 chars: the stack name is
@@ -212,7 +217,7 @@ func TestCuttingEdgeCluster(t *testing.T) {
 			"MngrUbuntu24": test.Platforms["Ubuntu24"].GetManager(),
 			"WrkRhel10":    test.Platforms["Rhel10"].GetWorker(),
 			"WrkRocky10":   test.Platforms["Rocky10"].GetWorker(),
-			"WrkSles15":    test.Platforms["Sles15"].GetWorker(),
+			"WrkSles16":    test.Platforms["Sles16"].GetWorker(),
 			"WrkUbuntu24":  test.Platforms["Ubuntu24"].GetWorker(),
 		},
 	})
@@ -270,7 +275,7 @@ func TestFIPSCluster(t *testing.T) {
 		SSHKeyAlgorithm: "rsa",
 		Nodegroups: map[string]interface{}{
 			"MngrUbuntu22FIPS": test.Platforms["Ubuntu22FIPS"].GetManager(),
-			"WrkWin2025":   test.Platforms["Windows2025"].GetWorker(),
+			"WrkWin2025":       test.Platforms["Windows2025"].GetWorker(),
 		},
 	})
 }

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -191,6 +191,29 @@ func TestModernCluster(t *testing.T) {
 	})
 }
 
+// TestCuttingEdgeCluster exercises rhel10/rocky10/ubuntu24 managers and workers
+// with sles15 as an additional worker, using the latest MCR and MKE versions.
+// Requires terraform-mirantis-modules/terraform-mirantis-provision-aws PR #22 (rhel_10/rocky_10
+// platform keys) to be merged and the module version bumped before this test can run.
+func TestCuttingEdgeCluster(t *testing.T) {
+	runSmokeTest(t, smokeConfig{
+		Name:            "cutting-edge",
+		MCRChannel:      "stable-29.4",
+		MKEVersion:      "3.9.2",
+		MSRVersion:      "3.1.18",
+		SSHKeyAlgorithm: "ed25519",
+		Nodegroups: map[string]interface{}{
+			"MngrRhel10":   test.Platforms["Rhel10"].GetManager(),
+			"MngrRocky10":  test.Platforms["Rocky10"].GetManager(),
+			"MngrUbuntu24": test.Platforms["Ubuntu24"].GetManager(),
+			"WrkRhel10":    test.Platforms["Rhel10"].GetWorker(),
+			"WrkRocky10":   test.Platforms["Rocky10"].GetWorker(),
+			"WrkSles15":    test.Platforms["Sles15"].GetWorker(),
+			"WrkUbuntu24":  test.Platforms["Ubuntu24"].GetWorker(),
+		},
+	})
+}
+
 // TestLegacyCluster exercises rhel8/rocky8/ubuntu22 managers and workers
 // with MCR stable-25.0 and MKE 3.8.8.
 func TestLegacyCluster(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `TestCuttingEdgeCluster` smoke test targeting gen-10 distributions: RHEL 10, Rocky 10, Ubuntu 24.04 as managers and workers, with SLES 16 as an additional worker
- Adds `Rhel10`, `Rocky10`, and `Sles16` platform definitions to `test/platforms.go`
- Adds `smoke-cutting-edge` Makefile target (50m timeout)
- Adds `smoke-cutting-edge` CI job triggered by the `smoke-cutting-edge` label

## ⚠️ Status: not yet a reliable gate — avoid for most scenarios

This test targets the newest OS releases *ahead* of MCR packaging/support. As of 2026-07-22, **MCR does not fully support most of these platforms yet**, so `smoke-cutting-edge` is expected to fail and should **not** be used as a merge gate or general-purpose smoke check. It exists to track forward-looking coverage and will go green incrementally as MCR ships support for each platform below.

| Platform | AMI | MCR packages install | MCR daemon starts | Status |
|---|---|---|---|---|
| Ubuntu 24.04 | ✅ | ✅ | ✅ | **Working** |
| RHEL 10 | ✅ | ✅ (`docker-ee-29.4.1m1-1.el10`) | ❌ | `systemctl start docker` fails after a clean install; confirmed 100% reproducible across 2 independent CI runs (2026-06-08, 2026-07-22). MCR product gap, not a launchpad bug — root cause not yet isolated (stderr suppressed by the install command). |
| Rocky 10 | ✅ | ✅ (same package, el10) | ❌ | Same failure as RHEL 10 — identical daemon-start gap. |
| SLES 16 | ✅ | ❌ | — | No Docker EE packages published at all; `repos.mirantis.com/sles/` only has `12/`, `12.3/`, `15/`. Fails immediately at the Install MCR phase. |
| AlmaLinux 10 | ✅ | ❌ | — | No MCR packages — excluded from this test entirely. |

**Net effect:** of the 7 nodes in `TestCuttingEdgeCluster` (3 managers + 4 workers), only the Ubuntu 24.04 nodes currently install successfully. RHEL 10, Rocky 10, and SLES 16 will all fail the Install MCR phase until MCR addresses the gaps above.

## Platform / dependency history

- Originally depended on [terraform-mirantis-modules/terraform-mirantis-provision-aws#22](https://github.com/terraform-mirantis-modules/terraform-mirantis-provision-aws/pull/22) for the `rhel_10`/`rocky_10` platform keys — **merged**, and `examples/terraform/aws-simple/` is now pinned to `>= 0.1.7`, which includes them.
- SLES worker was originally SLES 15 (working, has MCR support) and was switched to SLES 16 to track that platform ahead of MCR support landing — see status table above.

## Test plan

- [x] Merge terraform-mirantis-modules/terraform-mirantis-provision-aws#22
- [x] Bump provision-aws module version in `examples/terraform/aws-simple/`
- [x] Add `smoke-cutting-edge` label to this PR to trigger the CI job
- [ ] File/track MCR product bugs for the RHEL10/Rocky10 daemon-start gap and SLES16 package gap
- [ ] Re-verify `smoke-cutting-edge` goes green per-platform as each MCR gap is closed

Written by AI: claude-opus-4-8