### PR TITLE
style: clear pre-existing lint and gofmt debt

### DIFF
--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -60,7 +60,6 @@ func (c WindowsConfigurer) InstallMCRLicense(h os.Host, lic string) error {
 
 // InstallMCR install MCR on Windows.
 func (c WindowsConfigurer) InstallMCR(h os.Host, engineConfig commonconfig.MCRConfig) error {
-
 	installerPath, getInstallerErr := GetInstaller(engineConfig.InstallURLWindows)
 	if getInstallerErr != nil {
 		return fmt.Errorf("could not install MCR; %w", getInstallerErr)

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -94,14 +94,14 @@ func (i *Image) Exist(h *mkeconfig.Host) bool {
 
 // PullImages pulls multiple images parallelly by using a worker pool.
 func PullImages(h *mkeconfig.Host, images []*Image) error {
-	wp := workerpool.New(5)
+	pool := workerpool.New(5)
 
 	var mutex sync.Mutex
 	var lastError error
 
 	for _, image := range images {
 		i := image // So we can safely pass i forward to pool without it getting mutated
-		wp.Submit(func() {
+		pool.Submit(func() {
 			if err := i.Pull(h); err != nil {
 				mutex.Lock()
 				if lastError == nil {
@@ -115,7 +115,7 @@ func PullImages(h *mkeconfig.Host, images []*Image) error {
 	// Wait for all workers to complete before reading lastError.
 	// A deferred StopWait() would let the return expression evaluate
 	// before workers finish, potentially returning nil on a real error.
-	wp.StopWait()
+	pool.StopWait()
 	return lastError
 }
 

--- a/pkg/product/mke/config/cluster_spec.go
+++ b/pkg/product/mke/config/cluster_spec.go
@@ -180,7 +180,6 @@ func (c *ClusterSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("%w: missing spec.mcr.channel — the mcr block is required; set a channel (e.g. channel: stable-29.4)", errInvalidConfig)
 	}
 
-
 	if c.Hosts.Count(func(h *Host) bool { return h.Role == "msr" }) > 0 {
 		if specAlias.MSR == nil {
 			return fmt.Errorf("%w: hosts with msr role present, but no spec.msr defined", errInvalidConfig)

--- a/pkg/product/mke/config/host.go
+++ b/pkg/product/mke/config/host.go
@@ -86,7 +86,6 @@ type Host struct {
 	// private NIC IP is not routable across DCs but the SSH/floating address is.
 	SwarmAddressOverride string `yaml:"swarmAddress,omitempty"`
 
-
 	Metadata    *HostMetadata  `yaml:"-"`
 	MSRMetadata *MSRMetadata   `yaml:"-"`
 	Configurer  HostConfigurer `yaml:"-"`

--- a/pkg/product/mke/phase/validate_facts_test.go
+++ b/pkg/product/mke/phase/validate_facts_test.go
@@ -165,7 +165,7 @@ func TestValidateFactsPopulateSan(t *testing.T) {
 				Channel: "stable-25.0",
 			},
 			MKE: mkeconfig.MKEConfig{
-				Version: "3.6.0",
+				Version:  "3.6.0",
 				Metadata: &mkeconfig.MKEMetadata{},
 				InstallFlags: commonconfig.Flags{
 					"--foo",

--- a/test/platforms.go
+++ b/test/platforms.go
@@ -153,4 +153,3 @@ var Platforms = map[string]Platform{
 		UserData:   "sudo ufw allow 2377,7946,10250/tcp; sudo ufw allow 7946,4789/udp",
 	},
 }
-

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -112,7 +112,7 @@ func runSmokeTest(t *testing.T, cfg smokeConfig) {
 		"nodegroups":        cfg.Nodegroups,
 		"ssh_key_algorithm": cfg.SSHKeyAlgorithm,
 		"extra_tags": map[string]string{
-			"launchpad-smoke-test": "true",
+			"launchpad-smoke-test":      "true",
 			"launchpad-smoke-test-name": cfg.Name,
 		},
 	}
@@ -245,7 +245,7 @@ func TestFIPSCluster(t *testing.T) {
 		SSHKeyAlgorithm: "rsa",
 		Nodegroups: map[string]interface{}{
 			"MngrUbuntu22FIPS": test.Platforms["Ubuntu22FIPS"].GetManager(),
-			"WrkWin2025":   test.Platforms["Windows2025"].GetWorker(),
+			"WrkWin2025":       test.Platforms["Windows2025"].GetWorker(),
 		},
 	})
 }


### PR DESCRIPTION
## What
Clear pre-existing lint and `gofmt` debt on `main`. No functional changes.

## Why
`make lint` currently fails on `main` with 5 issues, and three files are not `gofmt`-clean. This is unrelated to any feature work — it just means anyone running `make lint` locally starts from a red baseline, and new violations are easy to miss in the noise.

## How
**`golangci-lint` (5 → 0 issues):**
- `pkg/product/mke/config/cluster_spec.go` — double blank line in `UnmarshalYAML` (`gci`)
- `pkg/product/mke/config/host.go` — formatting (`gci`)
- `pkg/configurer/windows.go` — stray blank line after the `InstallMCR` opening brace (`gofumpt`, `whitespace`); leftover from #640 removing `version := "latest"`
- `pkg/docker/image.go` — rename `wp` → `pool` (`varnamelen`). Deliberately matches the name already used on the rig v2 migration branch, so that rebase stays clean.

**`gofmt`** (not covered by `make lint`, which sets `run.tests: false`):
- `pkg/product/mke/phase/validate_facts_test.go`, `test/platforms.go`, `test/smoke/smoke_test.go` — struct field alignment and one trailing blank line

Everything except the `wp` → `pool` rename was applied by `golangci-lint run --fix` / `gofmt -w`; the rename was done via LSP so all three references moved together.

## Testing
- `make lint` → **0 issues**
- `gofmt -l` across `./pkg ./cmd ./test .` → **clean**
- `go build ./...`, `go vet ./...`, and `go vet -tags=integration ./test/...` all pass
- `go test ./pkg/...` passes

## Links
- JIRA: N/A (pure lint/format hygiene, no ticket)

## Checklist
- [ ] Tests added or updated (N/A — formatting only, no behaviour change)
- [ ] Docs updated if user-visible behaviour changed (N/A)
- [x] No debug output or dead code left in

Written by AI: claude-sonnet-5
